### PR TITLE
Adjust category picker checkbox styling

### DIFF
--- a/app/src/main/java/be/buithg/supergoal/presentation/ui/CategoryAdapter.kt
+++ b/app/src/main/java/be/buithg/supergoal/presentation/ui/CategoryAdapter.kt
@@ -1,8 +1,8 @@
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.CheckBox
 import android.widget.TextView
+import androidx.appcompat.widget.AppCompatCheckBox
 import androidx.recyclerview.widget.RecyclerView
 import be.buithg.supergoal.R
 
@@ -13,7 +13,7 @@ class CategoryAdapter(
 ) : RecyclerView.Adapter<CategoryAdapter.VH>() {
 
     inner class VH(v: View) : RecyclerView.ViewHolder(v) {
-        val cb: CheckBox = v.findViewById(R.id.cb)
+        val cb: AppCompatCheckBox = v.findViewById(R.id.cb)
         val tv: TextView = v.findViewById(R.id.tv)
         val divider: View = v.findViewById(R.id.divider)
     }

--- a/app/src/main/res/layout/item_category_single.xml
+++ b/app/src/main/res/layout/item_category_single.xml
@@ -1,5 +1,6 @@
 <!-- res/layout/item_category_single.xml -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="56dp"
     android:orientation="vertical">
@@ -10,14 +11,17 @@
         android:layout_weight="1"
         android:gravity="center_vertical">
 
-        <CheckBox
+        <androidx.appcompat.widget.AppCompatCheckBox
             android:id="@+id/cb"
             android:layout_width="24dp"
             android:layout_height="24dp"
-            android:button="@drawable/selector_check_square"
+            android:layout_marginEnd="12dp"
+            android:button="@null"
             android:focusable="false"
             android:clickable="false"
-            android:layout_marginEnd="12dp"/>
+            android:background="@drawable/checkbox_square"
+            app:buttonCompat="@drawable/checkbox_square"
+            app:useMaterialThemeColors="false" />
 
 
         <TextView


### PR DESCRIPTION
## Summary
- update the category picker item to use an AppCompatCheckBox with the custom red square drawable
- adjust the adapter to bind the AppCompatCheckBox view holder

## Testing
- ./gradlew lint *(fails: Android SDK is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3fbae7384832a9444733c405dfa75