### PR TITLE
Hook up bottom navigation to fragments

### DIFF
--- a/app/src/main/java/be/buithg/supergoal/MainActivity.kt
+++ b/app/src/main/java/be/buithg/supergoal/MainActivity.kt
@@ -5,23 +5,39 @@ import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
+import androidx.navigation.NavController
+import androidx.navigation.fragment.NavHostFragment
+import androidx.navigation.ui.setupWithNavController
+import com.google.android.material.bottomnavigation.BottomNavigationView
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class MainActivity : AppCompatActivity() {
+
+    private lateinit var navController: NavController
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContentView(R.layout.activity_main)
 
-        val bottom = findViewById<com.google.android.material.bottomnavigation.BottomNavigationView>(R.id.bottom_nav)
+        val bottom = findViewById<BottomNavigationView>(R.id.bottom_nav)
         bottom.itemIconTintList = null            // ← иконки остаются цветными
         bottom.itemTextColor = resources.getColorStateList(R.color.bottom_nav_text_selector, theme)
+
+        val navHost = supportFragmentManager
+            .findFragmentById(R.id.nav_host_fragment) as NavHostFragment
+        navController = navHost.navController
+        bottom.setupWithNavController(navController)
 
         ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.main)) { v, insets ->
             val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
             v.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom)
             insets
         }
+    }
+
+    override fun onSupportNavigateUp(): Boolean {
+        return navController.navigateUp() || super.onSupportNavigateUp()
     }
 }

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -3,21 +3,59 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/nav_graph.xml"
-    app:startDestination="@id/addGoalFragment">
+    app:startDestination="@id/nav_goals">
+
+    <fragment
+        android:id="@+id/nav_goals"
+        android:name="be.buithg.supergoal.presentation.ui.goal.GoalFragment"
+        android:label="fragment_goal"
+        tools:layout="@layout/fragment_goal" />
+
+    <fragment
+        android:id="@+id/nav_motivation"
+        android:name="be.buithg.supergoal.presentation.ui.article.ArticleFragment"
+        android:label="fragment_article"
+        tools:layout="@layout/fragment_article" />
+
+    <fragment
+        android:id="@+id/nav_analytics"
+        android:name="be.buithg.supergoal.presentation.ui.analytic.AnalyticFragment"
+        android:label="fragment_analytic"
+        tools:layout="@layout/fragment_analytic" />
+
+    <fragment
+        android:id="@+id/nav_challenges"
+        android:name="be.buithg.supergoal.presentation.ui.challenges.ChallengeFragment"
+        android:label="fragment_challenge"
+        tools:layout="@layout/fragment_challenge" />
+
+    <fragment
+        android:id="@+id/nav_settings"
+        android:name="be.buithg.supergoal.presentation.ui.settings.SettingsFragment"
+        android:label="fragment_settings"
+        tools:layout="@layout/fragment_settings" />
 
     <fragment
         android:id="@+id/splashFragment"
         android:name="be.buithg.supergoal.presentation.ui.splash.SplashFragment"
         android:label="fragment_splash_screen"
         tools:layout="@layout/fragment_splash_screen" />
-    <fragment
-        android:id="@+id/goalFragment"
-        android:name="be.buithg.supergoal.presentation.ui.goal.GoalFragment"
-        android:label="fragment_goal"
-        tools:layout="@layout/fragment_goal" />
+
     <fragment
         android:id="@+id/addGoalFragment"
         android:name="be.buithg.supergoal.presentation.ui.goal.AddGoalFragment"
         android:label="fragment_add_goal"
         tools:layout="@layout/fragment_add_goal" />
+
+    <fragment
+        android:id="@+id/goalDetailFragment"
+        android:name="be.buithg.supergoal.presentation.ui.goal.GoalDetailFragment"
+        android:label="fragment_goal_detail"
+        tools:layout="@layout/fragment_goal_detail" />
+
+    <fragment
+        android:id="@+id/challengeDetailFragment"
+        android:name="be.buithg.supergoal.presentation.ui.challenges.ChallengeDetailFragment"
+        android:label="fragment_challenge_detail"
+        tools:layout="@layout/fragment_challenge_detail" />
 </navigation>


### PR DESCRIPTION
## Summary
- connect the bottom navigation bar to the activity NavController so selections navigate between fragments
- add navigation graph destinations for goals, motivation, analytics, challenges, and settings fragments

## Testing
- ./gradlew lintDebug *(fails: SDK location not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d5294b3874832aac089908b0959cf7