### PR TITLE
Implement splash and onboarding navigation flow

### DIFF
--- a/app/src/main/java/be/buithg/supergoal/presentation/ui/onboarding/OnBoardingFragment.kt
+++ b/app/src/main/java/be/buithg/supergoal/presentation/ui/onboarding/OnBoardingFragment.kt
@@ -1,24 +1,46 @@
 package be.buithg.supergoal.presentation.ui.onboarding
 
+import android.content.Context
 import android.os.Bundle
-import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.findNavController
 import be.buithg.supergoal.R
 import be.buithg.supergoal.databinding.FragmentOnBoardingBinding
 
 class OnBoardingFragment : Fragment() {
 
-    private lateinit var binding: FragmentOnBoardingBinding
+    private var _binding: FragmentOnBoardingBinding? = null
+    private val binding get() = _binding!!
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View? {
-        binding = FragmentOnBoardingBinding.inflate(inflater, container, false)
+        savedInstanceState: Bundle?,
+    ): View {
+        _binding = FragmentOnBoardingBinding.inflate(inflater, container, false)
         return binding.root
     }
 
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
 
+        binding.btnGetStarted.setOnClickListener {
+            requireContext().markOnboardingSeen()
+            findNavController().navigate(R.id.action_onBoardingFragment_to_nav_goals)
+        }
+    }
+
+    private fun Context.markOnboardingSeen() {
+        getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .edit()
+            .putBoolean(KEY_HAS_SEEN_ONBOARDING, true)
+            .apply()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
 }

--- a/app/src/main/java/be/buithg/supergoal/presentation/ui/onboarding/OnboardingPreferences.kt
+++ b/app/src/main/java/be/buithg/supergoal/presentation/ui/onboarding/OnboardingPreferences.kt
@@ -1,0 +1,4 @@
+package be.buithg.supergoal.presentation.ui.onboarding
+
+internal const val PREFS_NAME = "super_goal_prefs"
+internal const val KEY_HAS_SEEN_ONBOARDING = "has_seen_onboarding"

--- a/app/src/main/java/be/buithg/supergoal/presentation/ui/splash/SplashFragment.kt
+++ b/app/src/main/java/be/buithg/supergoal/presentation/ui/splash/SplashFragment.kt
@@ -1,82 +1,114 @@
 package be.buithg.supergoal.presentation.ui.splash
 
-import android.animation.Animator
-import android.animation.AnimatorListenerAdapter
 import android.animation.ObjectAnimator
 import android.animation.ValueAnimator
+import android.content.Context
 import android.os.Bundle
-import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.animation.AccelerateDecelerateInterpolator
+import android.view.animation.LinearInterpolator
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
+import androidx.navigation.fragment.findNavController
 import be.buithg.supergoal.R
-import be.buithg.supergoal.databinding.FragmentSettingsBinding
 import be.buithg.supergoal.databinding.FragmentSplashScreenBinding
-import com.google.android.material.bottomnavigation.BottomNavigationView
+import be.buithg.supergoal.presentation.ui.onboarding.KEY_HAS_SEEN_ONBOARDING
+import be.buithg.supergoal.presentation.ui.onboarding.PREFS_NAME
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
+private const val SPLASH_DELAY_MS = 1400L
 
 class SplashFragment : Fragment() {
 
-    private lateinit var binding: FragmentSplashScreenBinding
+    private var _binding: FragmentSplashScreenBinding? = null
+    private val binding get() = _binding!!
+
     private var progressAnim: ValueAnimator? = null
     private var pulseX: ObjectAnimator? = null
     private var pulseY: ObjectAnimator? = null
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
-        savedInstanceState: Bundle?
+        savedInstanceState: Bundle?,
     ): View {
-        binding = FragmentSplashScreenBinding.inflate(inflater, container, false)
+        _binding = FragmentSplashScreenBinding.inflate(inflater, container, false)
         return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        // 1) Пульс логотипа (бесконечный, лёгкий)
+        startLogoPulse()
+        startProgressLoop()
+        launchNavigationCountdown()
+    }
+
+    private fun startLogoPulse() {
         pulseX = ObjectAnimator.ofFloat(binding.ivLogo, View.SCALE_X, 1f, 1.06f).apply {
             duration = 700
             repeatCount = ValueAnimator.INFINITE
             repeatMode = ValueAnimator.REVERSE
+            interpolator = AccelerateDecelerateInterpolator()
             start()
         }
         pulseY = ObjectAnimator.ofFloat(binding.ivLogo, View.SCALE_Y, 1f, 1.06f).apply {
             duration = 700
             repeatCount = ValueAnimator.INFINITE
             repeatMode = ValueAnimator.REVERSE
-            start()
-        }
-
-        // 2) Прогресс с задержкой старта
-        binding.progressCapsule.progress = 0
-        progressAnim = ValueAnimator.ofInt(0, 100).apply {
-            startDelay = 600L            // <- задержка
-            duration = 1800L
             interpolator = AccelerateDecelerateInterpolator()
-            addUpdateListener { anim ->
-                binding.progressCapsule.progress = anim.animatedValue as Int
-            }
-            addListener(object : AnimatorListenerAdapter() {
-                override fun onAnimationEnd(animation: Animator) {
-                    stopPulses()
-                    // TODO: перейти дальше по навигации:
-                    // findNavController().navigate(R.id.action_splash_to_home)
-                }
-            })
             start()
         }
     }
 
-    private fun stopPulses() {
-        pulseX?.cancel(); pulseY?.cancel()
+    private fun startProgressLoop() {
+        binding.progressCapsule.progress = 0
+        progressAnim = ValueAnimator.ofInt(0, 100).apply {
+            duration = 600L
+            repeatCount = ValueAnimator.INFINITE
+            repeatMode = ValueAnimator.RESTART
+            interpolator = LinearInterpolator()
+            addUpdateListener { anim ->
+                binding.progressCapsule.progress = anim.animatedValue as Int
+            }
+            start()
+        }
+    }
+
+    private fun launchNavigationCountdown() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            delay(SPLASH_DELAY_MS)
+            if (!isAdded) return@launch
+            val nextDestination = if (requireContext().hasSeenOnboarding()) {
+                R.id.action_splashFragment_to_nav_goals
+            } else {
+                R.id.action_splashFragment_to_onBoardingFragment
+            }
+            stopAnimations()
+            findNavController().navigate(nextDestination)
+        }
+    }
+
+    private fun Context.hasSeenOnboarding(): Boolean =
+        getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .getBoolean(KEY_HAS_SEEN_ONBOARDING, false)
+
+    private fun stopAnimations() {
+        progressAnim?.cancel()
+        pulseX?.cancel()
+        pulseY?.cancel()
         binding.ivLogo.scaleX = 1f
         binding.ivLogo.scaleY = 1f
     }
 
     override fun onDestroyView() {
         super.onDestroyView()
-        progressAnim?.cancel()
-        stopPulses()
+        stopAnimations()
+        progressAnim = null
+        pulseX = null
+        pulseY = null
+        _binding = null
     }
 }

--- a/app/src/main/res/layout/fragment_on_boarding.xml
+++ b/app/src/main/res/layout/fragment_on_boarding.xml
@@ -7,19 +7,36 @@
     android:background="@drawable/bg_combined"
     tools:context=".presentation.ui.onboarding.OnBoardingFragment">
 
-    <!-- Карточка -->
+    <TextView
+        android:id="@+id/tvTitle"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="32dp"
+        android:layout_marginTop="120dp"
+        android:layout_marginEnd="32dp"
+        android:fontFamily="@font/poppins_bold"
+        android:gravity="center"
+        android:text="@string/onboarding_title"
+        android:textColor="#FFFFFF"
+        android:textSize="32sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
     <com.google.android.material.card.MaterialCardView
         android:id="@+id/card"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="20dp"
+        android:layout_marginTop="32dp"
         android:layout_marginEnd="20dp"
-        app:cardBackgroundColor="#1F232B"
         android:layout_marginBottom="50dp"
+        app:cardBackgroundColor="#1F232B"
         app:cardCornerRadius="20dp"
-        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/btnGetStarted"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tvTitle"
         app:strokeColor="#FF4A3F"
         app:strokeWidth="2dp">
 
@@ -27,12 +44,11 @@
             android:id="@+id/tvSubtitle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:fontFamily="@font/poppins_bold"
+            android:fontFamily="@font/poppins_regular"
+            android:gravity="center"
             android:lineSpacingExtra="4dp"
             android:padding="20dp"
-            android:layout_marginTop="20dp"
-            android:layout_marginBottom="35dp"
-            android:text="Chart your constellations of skills, practice in short bursts, and collect stars as you grow."
+            android:text="@string/onboarding_subtitle"
             android:textColor="#FFFFFF"
             android:textSize="18sp" />
     </com.google.android.material.card.MaterialCardView>
@@ -46,15 +62,15 @@
         android:fontFamily="@font/poppins_bold"
         android:insetTop="0dp"
         android:insetBottom="0dp"
-        android:text="Get Started"
-        android:backgroundTint="#EE322E"
+        android:text="@string/onboarding_cta"
         android:textAllCaps="false"
         android:textColor="#FFFFFF"
         android:textSize="16sp"
         android:translationY="-24dp"
+        app:backgroundTint="#EE322E"
         app:cornerRadius="28dp"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/card" />
+        app:layout_constraintStart_toStartOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_splash_screen.xml
+++ b/app/src/main/res/layout/fragment_splash_screen.xml
@@ -8,16 +8,16 @@
 
     <LinearLayout
         android:layout_width="match_parent"
-        android:orientation="vertical"
+        android:layout_height="wrap_content"
         android:layout_gravity="center"
         android:gravity="center"
-        android:layout_height="wrap_content">
+        android:orientation="vertical">
 
         <ImageView
             android:id="@+id/ivLogo"
             android:layout_width="200dp"
             android:layout_height="200dp"
-            android:src="@drawable/ball_ic"/>
+            android:src="@drawable/ball_ic" />
 
         <ProgressBar
             android:id="@+id/progressCapsule"
@@ -25,13 +25,11 @@
             android:layout_width="match_parent"
             android:layout_height="24dp"
             android:layout_marginTop="20dp"
-            android:progressDrawable="@drawable/progress_capsule"
-            android:max="100"
             android:layout_marginHorizontal="40dp"
-            android:progress="40"
-            android:indeterminate="false"/>
-
-
+            android:max="100"
+            android:progress="0"
+            android:progressDrawable="@drawable/progress_capsule"
+            android:indeterminate="false" />
     </LinearLayout>
 
 </FrameLayout>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -3,7 +3,36 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/nav_graph.xml"
-    app:startDestination="@id/nav_goals">
+    app:startDestination="@id/splashFragment">
+
+    <fragment
+        android:id="@+id/splashFragment"
+        android:name="be.buithg.supergoal.presentation.ui.splash.SplashFragment"
+        android:label="fragment_splash_screen"
+        tools:layout="@layout/fragment_splash_screen">
+        <action
+            android:id="@+id/action_splashFragment_to_onBoardingFragment"
+            app:destination="@id/onBoardingFragment"
+            app:popUpTo="@id/splashFragment"
+            app:popUpToInclusive="true" />
+        <action
+            android:id="@+id/action_splashFragment_to_nav_goals"
+            app:destination="@id/nav_goals"
+            app:popUpTo="@id/splashFragment"
+            app:popUpToInclusive="true" />
+    </fragment>
+
+    <fragment
+        android:id="@+id/onBoardingFragment"
+        android:name="be.buithg.supergoal.presentation.ui.onboarding.OnBoardingFragment"
+        android:label="fragment_on_boarding"
+        tools:layout="@layout/fragment_on_boarding">
+        <action
+            android:id="@+id/action_onBoardingFragment_to_nav_goals"
+            app:destination="@id/nav_goals"
+            app:popUpTo="@id/onBoardingFragment"
+            app:popUpToInclusive="true" />
+    </fragment>
 
     <fragment
         android:id="@+id/nav_goals"
@@ -36,12 +65,6 @@
         tools:layout="@layout/fragment_settings" />
 
     <fragment
-        android:id="@+id/splashFragment"
-        android:name="be.buithg.supergoal.presentation.ui.splash.SplashFragment"
-        android:label="fragment_splash_screen"
-        tools:layout="@layout/fragment_splash_screen" />
-
-    <fragment
         android:id="@+id/addGoalFragment"
         android:name="be.buithg.supergoal.presentation.ui.goal.AddGoalFragment"
         android:label="fragment_add_goal"
@@ -58,9 +81,4 @@
         android:name="be.buithg.supergoal.presentation.ui.challenges.ChallengeDetailFragment"
         android:label="fragment_challenge_detail"
         tools:layout="@layout/fragment_challenge_detail" />
-    <fragment
-        android:id="@+id/onBoardingFragment"
-        android:name="be.buithg.supergoal.presentation.ui.onboarding.OnBoardingFragment"
-        android:label="fragment_on_boarding"
-        tools:layout="@layout/fragment_on_boarding" />
 </navigation>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,7 @@
 <resources>
     <string name="app_name">SuperGoal</string>
-    <!-- TODO: Remove or change this placeholder text -->
+    <string name="onboarding_title">Chart your path</string>
+    <string name="onboarding_subtitle">Chart your constellations of skills, practice in short bursts, and collect stars as you grow.</string>
+    <string name="onboarding_cta">Get Started</string>
     <string name="hello_blank_fragment">Hello blank fragment</string>
 </resources>


### PR DESCRIPTION
## Summary
- add shared preferences constants to persist the onboarding completion flag
- animate the splash screen while delaying navigation and route users based on the saved onboarding state
- refresh onboarding layout copy and wire navigation so users cannot return to splash/onboarding after progressing

## Testing
- ./gradlew lint *(fails: SDK location not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d5315d00dc832aa448810d0064255d