### PR TITLE
Implement goal screen with filtering and navigation

### DIFF
--- a/app/src/main/java/be/buithg/supergoal/presentation/ui/goal/GoalAdapter.kt
+++ b/app/src/main/java/be/buithg/supergoal/presentation/ui/goal/GoalAdapter.kt
@@ -1,0 +1,75 @@
+package be.buithg.supergoal.presentation.ui.goal
+
+import android.net.Uri
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.core.content.ContextCompat
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import be.buithg.supergoal.R
+import be.buithg.supergoal.databinding.GoalItemBinding
+import be.buithg.supergoal.domain.model.Goal
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import kotlin.math.roundToInt
+
+class GoalAdapter(
+    private val onGoalClicked: (Goal) -> Unit
+) : ListAdapter<Goal, GoalAdapter.GoalViewHolder>(DiffCallback) {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): GoalViewHolder {
+        val inflater = LayoutInflater.from(parent.context)
+        val binding = GoalItemBinding.inflate(inflater, parent, false)
+        return GoalViewHolder(binding, onGoalClicked)
+    }
+
+    override fun onBindViewHolder(holder: GoalViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+
+    class GoalViewHolder(
+        private val binding: GoalItemBinding,
+        private val onGoalClicked: (Goal) -> Unit
+    ) : RecyclerView.ViewHolder(binding.root) {
+
+        private val dateFormatter = SimpleDateFormat("MMM dd, yyyy", Locale.getDefault())
+
+        fun bind(goal: Goal) = with(binding) {
+            tvTitle.text = goal.title
+            tvCategory.text = goal.category.name.lowercase(Locale.getDefault()).replaceFirstChar {
+                if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString()
+            }
+
+            val progressValue = goal.progress.roundToInt().coerceIn(0, 100)
+            tvPercent.text = itemView.context.getString(R.string.goal_percent_format, progressValue)
+            pbProgress.progress = progressValue
+
+            val deadlineText = dateFormatter.format(Date(goal.deadlineMillis))
+            tvDeadline.text = deadlineText
+
+            if (goal.imageUri.isNullOrBlank()) {
+                ivCover.setImageDrawable(
+                    ContextCompat.getDrawable(itemView.context, R.drawable.image_placeholder)
+                )
+            } else {
+                ivCover.setImageDrawable(null)
+                ivCover.setImageURI(Uri.parse(goal.imageUri))
+                if (ivCover.drawable == null) {
+                    ivCover.setImageDrawable(
+                        ContextCompat.getDrawable(itemView.context, R.drawable.image_placeholder)
+                    )
+                }
+            }
+
+            root.setOnClickListener { onGoalClicked(goal) }
+        }
+    }
+
+    private object DiffCallback : DiffUtil.ItemCallback<Goal>() {
+        override fun areItemsTheSame(oldItem: Goal, newItem: Goal): Boolean = oldItem.id == newItem.id
+
+        override fun areContentsTheSame(oldItem: Goal, newItem: Goal): Boolean = oldItem == newItem
+    }
+}

--- a/app/src/main/java/be/buithg/supergoal/presentation/ui/goal/GoalDetailFragment.kt
+++ b/app/src/main/java/be/buithg/supergoal/presentation/ui/goal/GoalDetailFragment.kt
@@ -5,21 +5,33 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
-import be.buithg.supergoal.R
-import be.buithg.supergoal.databinding.FragmentArticleBinding
+import androidx.navigation.fragment.navArgs
 import be.buithg.supergoal.databinding.FragmentGoalDetailBinding
 
 class GoalDetailFragment : Fragment() {
 
-    private lateinit var binding: FragmentGoalDetailBinding
+    private var _binding: FragmentGoalDetailBinding? = null
+    private val binding get() = _binding!!
+
+    private val args: GoalDetailFragmentArgs by navArgs()
 
     override fun onCreateView(
-        inflater: LayoutInflater, container: ViewGroup?,
+        inflater: LayoutInflater,
+        container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
-        binding = FragmentGoalDetailBinding.inflate(inflater, container, false)
+    ): View {
+        _binding = FragmentGoalDetailBinding.inflate(inflater, container, false)
         return binding.root
     }
 
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        binding.root.tag = args.goalId
+        // TODO: consume goalId when detail screen is implemented
+    }
 
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
 }

--- a/app/src/main/java/be/buithg/supergoal/presentation/ui/goal/GoalFilter.kt
+++ b/app/src/main/java/be/buithg/supergoal/presentation/ui/goal/GoalFilter.kt
@@ -1,0 +1,7 @@
+package be.buithg.supergoal.presentation.ui.goal
+
+enum class GoalFilter {
+    ALL,
+    ACTIVE,
+    ARCHIVED
+}

--- a/app/src/main/java/be/buithg/supergoal/presentation/ui/goal/GoalFragment.kt
+++ b/app/src/main/java/be/buithg/supergoal/presentation/ui/goal/GoalFragment.kt
@@ -4,22 +4,93 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.TextView
+import androidx.core.content.ContextCompat
+import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import androidx.navigation.fragment.findNavController
+import androidx.recyclerview.widget.LinearLayoutManager
 import be.buithg.supergoal.R
-import be.buithg.supergoal.databinding.FragmentArticleBinding
 import be.buithg.supergoal.databinding.FragmentGoalBinding
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 
+@AndroidEntryPoint
 class GoalFragment : Fragment() {
 
-    private lateinit var binding: FragmentGoalBinding
+    private var _binding: FragmentGoalBinding? = null
+    private val binding get() = _binding!!
+
+    private val viewModel: GoalViewModel by viewModels()
+
+    private val goalAdapter = GoalAdapter { goal ->
+        val action = GoalFragmentDirections.actionNavGoalsToGoalDetailFragment(goal.id)
+        findNavController().navigate(action)
+    }
 
     override fun onCreateView(
-        inflater: LayoutInflater, container: ViewGroup?,
+        inflater: LayoutInflater,
+        container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
-        binding = FragmentGoalBinding.inflate(inflater, container, false)
+    ): View {
+        _binding = FragmentGoalBinding.inflate(inflater, container, false)
         return binding.root
     }
 
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setupRecyclerView()
+        setupClicks()
+        observeUiState()
+    }
 
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+    private fun setupRecyclerView() = with(binding.rvGoals) {
+        layoutManager = LinearLayoutManager(requireContext())
+        adapter = goalAdapter
+        setHasFixedSize(false)
+    }
+
+    private fun setupClicks() = with(binding) {
+        btnAddGoal.setOnClickListener {
+            findNavController().navigate(R.id.action_nav_goals_to_addGoalFragment)
+        }
+
+        btnAll.setOnClickListener { viewModel.onFilterSelected(GoalFilter.ALL) }
+        btnActive.setOnClickListener { viewModel.onFilterSelected(GoalFilter.ACTIVE) }
+        btnArchived.setOnClickListener { viewModel.onFilterSelected(GoalFilter.ARCHIVED) }
+    }
+
+    private fun observeUiState() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.uiState.collect { state ->
+                    goalAdapter.submitList(state.goals)
+                    binding.tvEmptyState.isVisible = state.isEmpty
+                    updateFilterState(state.selectedFilter)
+                }
+            }
+        }
+    }
+
+    private fun updateFilterState(selectedFilter: GoalFilter) = with(binding) {
+        fun TextView.applyState(isSelected: Boolean) {
+            setBackgroundResource(
+                if (isSelected) R.drawable.bg_tab_selected else R.drawable.bg_tab_unselected
+            )
+            setTextColor(ContextCompat.getColor(requireContext(), android.R.color.white))
+        }
+
+        btnAll.applyState(selectedFilter == GoalFilter.ALL)
+        btnActive.applyState(selectedFilter == GoalFilter.ACTIVE)
+        btnArchived.applyState(selectedFilter == GoalFilter.ARCHIVED)
+    }
 }

--- a/app/src/main/java/be/buithg/supergoal/presentation/ui/goal/GoalUiState.kt
+++ b/app/src/main/java/be/buithg/supergoal/presentation/ui/goal/GoalUiState.kt
@@ -1,0 +1,10 @@
+package be.buithg.supergoal.presentation.ui.goal
+
+import be.buithg.supergoal.domain.model.Goal
+
+data class GoalUiState(
+    val goals: List<Goal> = emptyList(),
+    val selectedFilter: GoalFilter = GoalFilter.ALL
+) {
+    val isEmpty: Boolean get() = goals.isEmpty()
+}

--- a/app/src/main/java/be/buithg/supergoal/presentation/ui/goal/GoalViewModel.kt
+++ b/app/src/main/java/be/buithg/supergoal/presentation/ui/goal/GoalViewModel.kt
@@ -1,0 +1,46 @@
+package be.buithg.supergoal.presentation.ui.goal
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import be.buithg.supergoal.domain.usecase.GoalUseCases
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+
+@HiltViewModel
+class GoalViewModel @Inject constructor(
+    goalUseCases: GoalUseCases
+) : ViewModel() {
+
+    private val selectedFilter = MutableStateFlow(GoalFilter.ALL)
+
+    private val goalsFlow = goalUseCases.observeGoals()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
+    val uiState: StateFlow<GoalUiState> = combine(selectedFilter, goalsFlow) { filter, goals ->
+        val filteredGoals = when (filter) {
+            GoalFilter.ALL -> goals
+            GoalFilter.ACTIVE -> goals.filterNot { it.isCompleted }
+            GoalFilter.ARCHIVED -> goals.filter { it.isCompleted }
+        }
+
+        GoalUiState(
+            goals = filteredGoals,
+            selectedFilter = filter
+        )
+    }.stateIn(
+        viewModelScope,
+        SharingStarted.WhileSubscribed(5_000),
+        GoalUiState()
+    )
+
+    fun onFilterSelected(filter: GoalFilter) {
+        if (selectedFilter.value != filter) {
+            selectedFilter.value = filter
+        }
+    }
+}

--- a/app/src/main/res/layout/fragment_goal.xml
+++ b/app/src/main/res/layout/fragment_goal.xml
@@ -49,7 +49,7 @@
 
         <!-- All -->
         <TextView
-            android:id="@+id/btn_all"
+            android:id="@+id/btnAll"
             android:layout_width="100dp"
             android:layout_height="40dp"
             android:layout_marginEnd="12dp"
@@ -62,7 +62,7 @@
 
         <!-- Active -->
         <TextView
-            android:id="@+id/btn_active"
+            android:id="@+id/btnActive"
             android:layout_width="100dp"
             android:layout_height="40dp"
             android:layout_marginEnd="12dp"
@@ -75,7 +75,7 @@
 
         <!-- Archived -->
         <TextView
-            android:id="@+id/btn_archived"
+            android:id="@+id/btnArchived"
             android:layout_width="100dp"
             android:layout_height="40dp"
             android:gravity="center"
@@ -87,9 +87,35 @@
 
     </LinearLayout>
 
-    <androidx.recyclerview.widget.RecyclerView
+    <FrameLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_marginHorizontal="20dp"/>
+        android:layout_height="0dp"
+        android:layout_marginHorizontal="20dp"
+        android:layout_marginBottom="20dp"
+        android:layout_weight="1">
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/rvGoals"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:clipToPadding="false"
+            android:overScrollMode="never"
+            android:paddingBottom="24dp"
+            tools:listitem="@layout/goal_item" />
+
+        <TextView
+            android:id="@+id/tvEmptyState"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:gravity="center"
+            android:padding="32dp"
+            android:text="@string/goal_empty_state"
+            android:textColor="@android:color/white"
+            android:textSize="16sp"
+            android:visibility="gone"
+            android:fontFamily="@font/poppins_regular" />
+
+    </FrameLayout>
 
 </LinearLayout>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -9,7 +9,16 @@
         android:id="@+id/nav_goals"
         android:name="be.buithg.supergoal.presentation.ui.goal.GoalFragment"
         android:label="fragment_goal"
-        tools:layout="@layout/fragment_goal" />
+        tools:layout="@layout/fragment_goal">
+
+        <action
+            android:id="@+id/action_nav_goals_to_addGoalFragment"
+            app:destination="@id/addGoalFragment" />
+
+        <action
+            android:id="@+id/action_nav_goals_to_goalDetailFragment"
+            app:destination="@id/goalDetailFragment" />
+    </fragment>
 
     <fragment
         android:id="@+id/nav_motivation"
@@ -51,7 +60,11 @@
         android:id="@+id/goalDetailFragment"
         android:name="be.buithg.supergoal.presentation.ui.goal.GoalDetailFragment"
         android:label="fragment_goal_detail"
-        tools:layout="@layout/fragment_goal_detail" />
+        tools:layout="@layout/fragment_goal_detail">
+        <argument
+            android:name="goalId"
+            app:argType="long" />
+    </fragment>
 
     <fragment
         android:id="@+id/challengeDetailFragment"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
     <string name="app_name">SuperGoal</string>
-    <!-- TODO: Remove or change this placeholder text -->
-    <string name="hello_blank_fragment">Hello blank fragment</string>
+    <string name="goal_empty_state">No goals yet. Add your first goal to track execution</string>
+    <string name="goal_percent_format">%1$d%%</string>
 </resources>


### PR DESCRIPTION
## Summary
- add goal list view model, UI state, and adapter to render and filter goals
- redesign the goal fragment UI with filter tabs, empty state, and navigation hooks to add/detail screens
- wire navigation graph to pass goal identifiers into the detail screen and prepare the fragment for args

## Testing
- ./gradlew test *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d5317f9864832a9042d141e4fe1de5