### PR TITLE
Implement goal screen with filtering and navigation

### DIFF
--- a/app/src/main/java/be/buithg/supergoal/presentation/ui/goal/GoalAdapter.kt
+++ b/app/src/main/java/be/buithg/supergoal/presentation/ui/goal/GoalAdapter.kt
@@ -1,0 +1,61 @@
+package be.buithg.supergoal.presentation.ui.goal
+
+import android.net.Uri
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import be.buithg.supergoal.R
+import be.buithg.supergoal.databinding.GoalItemBinding
+
+class GoalAdapter(
+    private val onGoalClick: (GoalListItem) -> Unit,
+) : ListAdapter<GoalListItem, GoalAdapter.GoalViewHolder>(DiffCallback) {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): GoalViewHolder {
+        val inflater = LayoutInflater.from(parent.context)
+        val binding = GoalItemBinding.inflate(inflater, parent, false)
+        return GoalViewHolder(binding, onGoalClick)
+    }
+
+    override fun onBindViewHolder(holder: GoalViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+
+    class GoalViewHolder(
+        private val binding: GoalItemBinding,
+        private val onGoalClick: (GoalListItem) -> Unit,
+    ) : RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(item: GoalListItem) = with(binding) {
+            tvTitle.text = item.title
+            tvCategory.text = item.category
+            tvPercent.text = item.progressText
+            pbProgress.progress = item.progressPercentage
+            tvDeadline.text = item.deadline
+
+            if (!item.imageUri.isNullOrBlank()) {
+                val uri = runCatching { Uri.parse(item.imageUri) }.getOrNull()
+                if (uri != null) {
+                    ivCover.setImageURI(null)
+                    ivCover.setImageURI(uri)
+                } else {
+                    ivCover.setImageResource(R.drawable.ic_launcher_background)
+                }
+            } else {
+                ivCover.setImageResource(R.drawable.ic_launcher_background)
+            }
+
+            root.setOnClickListener { onGoalClick(item) }
+        }
+    }
+
+    private object DiffCallback : DiffUtil.ItemCallback<GoalListItem>() {
+        override fun areItemsTheSame(oldItem: GoalListItem, newItem: GoalListItem): Boolean =
+            oldItem.id == newItem.id
+
+        override fun areContentsTheSame(oldItem: GoalListItem, newItem: GoalListItem): Boolean =
+            oldItem == newItem
+    }
+}

--- a/app/src/main/java/be/buithg/supergoal/presentation/ui/goal/GoalFragment.kt
+++ b/app/src/main/java/be/buithg/supergoal/presentation/ui/goal/GoalFragment.kt
@@ -4,22 +4,98 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.os.bundleOf
+import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import androidx.navigation.fragment.findNavController
+import androidx.recyclerview.widget.LinearLayoutManager
 import be.buithg.supergoal.R
-import be.buithg.supergoal.databinding.FragmentArticleBinding
 import be.buithg.supergoal.databinding.FragmentGoalBinding
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 
+@AndroidEntryPoint
 class GoalFragment : Fragment() {
 
-    private lateinit var binding: FragmentGoalBinding
+    private var _binding: FragmentGoalBinding? = null
+    private val binding get() = _binding!!
+
+    private val viewModel: GoalViewModel by viewModels()
+    private lateinit var goalAdapter: GoalAdapter
 
     override fun onCreateView(
-        inflater: LayoutInflater, container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View? {
-        binding = FragmentGoalBinding.inflate(inflater, container, false)
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        _binding = FragmentGoalBinding.inflate(inflater, container, false)
         return binding.root
     }
 
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setupRecyclerView()
+        setupClicks()
+        collectUiState()
+    }
 
+    override fun onDestroyView() {
+        super.onDestroyView()
+        binding.rvGoals.adapter = null
+        _binding = null
+    }
+
+    private fun setupRecyclerView() {
+        goalAdapter = GoalAdapter(onGoalClick = ::openGoalDetails)
+        binding.rvGoals.apply {
+            layoutManager = LinearLayoutManager(requireContext())
+            adapter = goalAdapter
+        }
+    }
+
+    private fun setupClicks() = with(binding) {
+        btnAddGoal.setOnClickListener {
+            findNavController().navigate(R.id.addGoalFragment)
+        }
+        btnAll.setOnClickListener { viewModel.onFilterSelected(GoalFilter.All) }
+        btnActive.setOnClickListener { viewModel.onFilterSelected(GoalFilter.Active) }
+        btnArchived.setOnClickListener { viewModel.onFilterSelected(GoalFilter.Archived) }
+    }
+
+    private fun collectUiState() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.uiState.collect { state ->
+                    goalAdapter.submitList(state.goals)
+                    binding.tvEmptyState.isVisible = state.isEmpty
+                    binding.rvGoals.isVisible = state.goals.isNotEmpty()
+                    updateFilterSelection(state.selectedFilter)
+                }
+            }
+        }
+    }
+
+    private fun updateFilterSelection(selectedFilter: GoalFilter) = with(binding) {
+        val selectedBackground = R.drawable.bg_tab_selected
+        val unselectedBackground = R.drawable.bg_tab_unselected
+
+        btnAll.setBackgroundResource(
+            if (selectedFilter == GoalFilter.All) selectedBackground else unselectedBackground,
+        )
+        btnActive.setBackgroundResource(
+            if (selectedFilter == GoalFilter.Active) selectedBackground else unselectedBackground,
+        )
+        btnArchived.setBackgroundResource(
+            if (selectedFilter == GoalFilter.Archived) selectedBackground else unselectedBackground,
+        )
+    }
+
+    private fun openGoalDetails(goal: GoalListItem) {
+        val arguments = bundleOf("goalId" to goal.id)
+        findNavController().navigate(R.id.goalDetailFragment, arguments)
+    }
 }

--- a/app/src/main/java/be/buithg/supergoal/presentation/ui/goal/GoalViewModel.kt
+++ b/app/src/main/java/be/buithg/supergoal/presentation/ui/goal/GoalViewModel.kt
@@ -1,0 +1,107 @@
+package be.buithg.supergoal.presentation.ui.goal
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import be.buithg.supergoal.domain.model.Goal
+import be.buithg.supergoal.domain.model.GoalCategory
+import be.buithg.supergoal.domain.usecase.GoalUseCases
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlin.math.roundToInt
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+@HiltViewModel
+class GoalViewModel @Inject constructor(
+    private val goalUseCases: GoalUseCases,
+) : ViewModel() {
+
+    private val dateFormatter = SimpleDateFormat("MMM dd, yyyy", Locale.getDefault())
+
+    private val filter = MutableStateFlow(GoalFilter.All)
+
+    val uiState: StateFlow<GoalUiState> = filter
+        .flatMapLatest { selectedFilter ->
+            val source = when (selectedFilter) {
+                GoalFilter.All -> goalUseCases.observeGoals()
+                GoalFilter.Active -> goalUseCases.observeActiveGoals()
+                GoalFilter.Archived -> goalUseCases.observeCompletedGoals()
+            }
+            source.map { goals ->
+                GoalUiState(
+                    selectedFilter = selectedFilter,
+                    goals = goals.map(::toGoalListItem),
+                )
+            }
+        }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5_000),
+            initialValue = GoalUiState(),
+        )
+
+    fun onFilterSelected(goalFilter: GoalFilter) {
+        if (filter.value != goalFilter) {
+            filter.value = goalFilter
+        }
+    }
+
+    private fun toGoalListItem(goal: Goal): GoalListItem {
+        val safeProgress = goal.progress.coerceIn(0.0, 100.0)
+        val progressPercentage = safeProgress.roundToInt()
+        val formattedDeadline = synchronized(dateFormatter) {
+            dateFormatter.format(Date(goal.deadlineMillis))
+        }
+
+        return GoalListItem(
+            id = goal.id,
+            title = goal.title,
+            category = goal.category.toDisplayName(),
+            progressPercentage = progressPercentage,
+            progressText = "$progressPercentage%",
+            deadline = formattedDeadline,
+            imageUri = goal.imageUri,
+        )
+    }
+
+    private fun GoalCategory.toDisplayName(): String {
+        val lowercase = name.lowercase(Locale.getDefault())
+        return lowercase.replaceFirstChar { character ->
+            if (character.isLowerCase()) {
+                character.titlecase(Locale.getDefault())
+            } else {
+                character.toString()
+            }
+        }
+    }
+}
+
+enum class GoalFilter {
+    All,
+    Active,
+    Archived,
+}
+
+data class GoalUiState(
+    val selectedFilter: GoalFilter = GoalFilter.All,
+    val goals: List<GoalListItem> = emptyList(),
+) {
+    val isEmpty: Boolean get() = goals.isEmpty()
+}
+
+data class GoalListItem(
+    val id: Long,
+    val title: String,
+    val category: String,
+    val progressPercentage: Int,
+    val progressText: String,
+    val deadline: String,
+    val imageUri: String?,
+)

--- a/app/src/main/res/layout/fragment_goal.xml
+++ b/app/src/main/res/layout/fragment_goal.xml
@@ -12,8 +12,8 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginHorizontal="20dp"
-        android:orientation="horizontal"
         android:gravity="center_vertical"
+        android:orientation="horizontal"
         android:paddingTop="25dp"
         android:paddingBottom="8dp">
 
@@ -42,8 +42,8 @@
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:gravity="center"
         android:layout_marginHorizontal="20dp"
+        android:gravity="center"
         android:orientation="horizontal"
         android:padding="16dp">
 
@@ -87,9 +87,25 @@
 
     </LinearLayout>
 
-    <androidx.recyclerview.widget.RecyclerView
+    <TextView
+        android:id="@+id/tvEmptyState"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_marginHorizontal="20dp"/>
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="20dp"
+        android:layout_marginTop="32dp"
+        android:fontFamily="@font/poppins_regular"
+        android:gravity="center"
+        android:text="No goals yet. Add your first goal to track execution"
+        android:textColor="#8FFFFFFF"
+        android:textSize="16sp"
+        android:visibility="gone" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/rvGoals"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_marginHorizontal="20dp"
+        android:layout_marginTop="8dp"
+        android:layout_weight="1"/>
 
 </LinearLayout>


### PR DESCRIPTION
## Summary
- implement a dedicated view model and adapter for the goal list, producing formatted items for display
- update the goal screen fragment to show filtered goals, handle navigation, and expose an empty state message when needed
- adjust the goal layout to add an empty placeholder and recycler view identifiers for binding

## Testing
- `./gradlew lint` *(fails: SDK location not configured in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d55454acb8832a942f63dfca8d5a57