### PR TITLE
Match Goal detail subgoal item styling to add goal categories

### DIFF
--- a/app/src/main/java/be/buithg/supergoal/presentation/ui/goal/GoalDetailSubGoalAdapter.kt
+++ b/app/src/main/java/be/buithg/supergoal/presentation/ui/goal/GoalDetailSubGoalAdapter.kt
@@ -2,6 +2,7 @@ package be.buithg.supergoal.presentation.ui.goal
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.core.view.isVisible
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
@@ -18,7 +19,7 @@ class GoalDetailSubGoalAdapter(
     }
 
     override fun onBindViewHolder(holder: SubGoalViewHolder, position: Int) {
-        holder.bind(getItem(position))
+        holder.bind(getItem(position), position == itemCount - 1)
     }
 
     class SubGoalViewHolder(
@@ -26,13 +27,23 @@ class GoalDetailSubGoalAdapter(
         private val onCheckedChanged: (Long, Boolean) -> Unit,
     ) : RecyclerView.ViewHolder(binding.root) {
 
-        fun bind(item: GoalDetailSubGoalItem) = with(binding) {
-            cbSubGoal.setOnCheckedChangeListener(null)
-            cbSubGoal.isChecked = item.isCompleted
-            cbSubGoal.setOnCheckedChangeListener { _, isChecked ->
-                onCheckedChanged(item.id, isChecked)
-            }
+        fun bind(item: GoalDetailSubGoalItem, isLast: Boolean) = with(binding) {
             tvSubGoalTitle.text = item.title
+
+            val isChecked = item.isCompleted
+            checkContainer.isSelected = isChecked
+            checkIcon.isVisible = isChecked
+            divider.isVisible = !isLast
+
+            val clickListener = {
+                val newChecked = !checkContainer.isSelected
+                checkContainer.isSelected = newChecked
+                checkIcon.isVisible = newChecked
+                onCheckedChanged(item.id, newChecked)
+            }
+
+            root.setOnClickListener { clickListener() }
+            checkContainer.setOnClickListener { clickListener() }
         }
     }
 

--- a/app/src/main/res/layout/item_detail_subgoal.xml
+++ b/app/src/main/res/layout/item_detail_subgoal.xml
@@ -1,30 +1,50 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:layout_marginTop="12dp"
-    android:background="@drawable/bg_input_goal_for_item"
-    android:gravity="center_vertical"
-    android:orientation="horizontal"
-    android:paddingStart="16dp"
-    android:paddingTop="12dp"
-    android:paddingEnd="16dp"
-    android:paddingBottom="12dp">
+    android:layout_height="56dp"
+    android:clickable="true"
+    android:focusable="true"
+    android:foreground="?attr/selectableItemBackground"
+    android:orientation="vertical">
 
-    <androidx.appcompat.widget.AppCompatCheckBox
-        android:id="@+id/cbSubGoal"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:button="@drawable/selector_check_square"
-        android:layout_marginEnd="12dp" />
-
-    <TextView
-        android:id="@+id/tvSubGoalTitle"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
         android:layout_weight="1"
-        android:fontFamily="@font/poppins_regular"
-        android:textColor="@android:color/white"
-        android:textSize="16sp" />
+        android:gravity="center_vertical">
 
+        <FrameLayout
+            android:id="@+id/check_container"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:layout_marginEnd="12dp"
+            android:background="@drawable/bg_category_checkbox"
+            android:gravity="center">
+
+            <ImageView
+                android:id="@+id/check_icon"
+                android:layout_width="16dp"
+                android:layout_height="16dp"
+                android:layout_gravity="center"
+                android:contentDescription="@null"
+                android:src="@drawable/ic_check_white_16"
+                android:visibility="gone" />
+        </FrameLayout>
+
+        <TextView
+            android:id="@+id/tvSubGoalTitle"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:textColor="#FFFFFFFF"
+            android:textSize="16sp" />
+    </LinearLayout>
+
+    <View
+        android:id="@+id/divider"
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="#33FFFFFF" />
 </LinearLayout>


### PR DESCRIPTION
## Summary
- restyle the goal detail subgoal row to reuse the category single visual language
- replace the checkbox behaviour with a custom toggle that mirrors the category selection UX
- make the entire row clickable and propagate selection changes immediately

## Testing
- `./gradlew lintDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d58e7c6af0832a9284a1b13b0a06df