### PR TITLE
Convert analytics overall progress to linear bar

### DIFF
--- a/app/src/main/java/be/buithg/supergoal/presentation/ui/analytic/AnalyticFragment.kt
+++ b/app/src/main/java/be/buithg/supergoal/presentation/ui/analytic/AnalyticFragment.kt
@@ -1,21 +1,164 @@
 package be.buithg.supergoal.presentation.ui.analytic
 
+import android.content.res.ColorStateList
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.LinearLayout
+import androidx.core.content.ContextCompat
+import androidx.core.view.ViewCompat
+import androidx.core.view.isVisible
+import androidx.core.view.updateLayoutParams
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import be.buithg.supergoal.R
+import be.buithg.supergoal.databinding.FragmentAnalyticBinding
+import be.buithg.supergoal.databinding.ItemAnalyticsLegendBinding
+import be.buithg.supergoal.domain.model.GoalCategory
+import be.buithg.supergoal.presentation.ui.custom.AnalyticsPieChartView
+import dagger.hilt.android.AndroidEntryPoint
+import java.util.Locale
+import kotlin.math.roundToInt
+import kotlinx.coroutines.launch
 
-
+@AndroidEntryPoint
 class AnalyticFragment : Fragment() {
 
+    private var _binding: FragmentAnalyticBinding? = null
+    private val binding get() = _binding!!
+
+    private val viewModel: AnalyticViewModel by viewModels()
+
     override fun onCreateView(
-        inflater: LayoutInflater, container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View? {
-        // Inflate the layout for this fragment
-        return inflater.inflate(R.layout.fragment_analytic, container, false)
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        _binding = FragmentAnalyticBinding.inflate(inflater, container, false)
+        return binding.root
     }
 
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        collectUiState()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+    private fun collectUiState() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.uiState.collect(::renderState)
+            }
+        }
+    }
+
+    private fun renderState(state: AnalyticUiState) = with(binding) {
+        overallContainer.isVisible = state.hasOverallProgress
+        tvOverallEmpty.isVisible = !state.hasOverallProgress
+
+        if (state.hasOverallProgress) {
+            val completedPercent = state.overallProgress.coerceIn(0, 100)
+            val remainingPercent = (100 - completedPercent).coerceAtLeast(0)
+
+            updateOverallBar(completedPercent, remainingPercent)
+            tvOverallPercent.text = getString(R.string.analytics_percent_value, completedPercent)
+            tvOverallRemainingPercent.text = getString(R.string.analytics_percent_value, remainingPercent)
+        }
+
+        val hasCategoryData = state.hasCategoryShares
+        pieChartView.isVisible = hasCategoryData
+        legendContainer.isVisible = hasCategoryData
+        tvPieEmpty.isVisible = !hasCategoryData
+
+        if (hasCategoryData) {
+            val slices = state.categoryShares.map { share ->
+                val color = ContextCompat.getColor(requireContext(), share.category.toColorRes())
+                AnalyticsPieChartView.Slice(
+                    fraction = (share.percentage / 100.0).toFloat(),
+                    color = color,
+                )
+            }
+            pieChartView.setData(slices)
+            renderLegend(state)
+        } else {
+            pieChartView.setData(emptyList())
+            legendContainer.removeAllViews()
+        }
+    }
+
+    private fun FragmentAnalyticBinding.updateOverallBar(
+        completedPercent: Int,
+        remainingPercent: Int,
+    ) {
+        val hasCompleted = completedPercent > 0
+        val hasRemaining = remainingPercent > 0
+
+        overallProgressCompletedSegment.isVisible = hasCompleted
+        overallProgressRemainingSegment.isVisible = hasRemaining
+
+        tvOverallPercent.isVisible = hasCompleted
+        tvOverallRemainingPercent.isVisible = hasRemaining
+
+        overallProgressCompletedSegment.updateLayoutParams<LinearLayout.LayoutParams> {
+            weight = if (hasCompleted) completedPercent.toFloat() else 0f
+        }
+        overallProgressRemainingSegment.updateLayoutParams<LinearLayout.LayoutParams> {
+            weight = if (hasRemaining) remainingPercent.toFloat() else 0f
+        }
+
+        val completedBackground = if (hasRemaining) {
+            R.drawable.bg_overall_progress_completed
+        } else {
+            R.drawable.bg_overall_progress_completed_full
+        }
+        val remainingBackground = if (hasCompleted) {
+            R.drawable.bg_overall_progress_remaining
+        } else {
+            R.drawable.bg_overall_progress_remaining_full
+        }
+
+        overallProgressCompletedSegment.setBackgroundResource(completedBackground)
+        overallProgressRemainingSegment.setBackgroundResource(remainingBackground)
+    }
+
+    private fun renderLegend(state: AnalyticUiState) {
+        val inflater = LayoutInflater.from(requireContext())
+        binding.legendContainer.removeAllViews()
+        state.categoryShares.forEach { share ->
+            val itemBinding = ItemAnalyticsLegendBinding.inflate(inflater, binding.legendContainer, false)
+            val colorRes = share.category.toColorRes()
+            val color = ContextCompat.getColor(requireContext(), colorRes)
+            ViewCompat.setBackgroundTintList(itemBinding.vLegendColor, ColorStateList.valueOf(color))
+            itemBinding.tvLegendTitle.text = share.category.toDisplayName()
+            itemBinding.tvLegendPercent.text = getString(
+                R.string.analytics_percent_value,
+                share.percentage.roundToInt(),
+            )
+            binding.legendContainer.addView(itemBinding.root)
+        }
+    }
+
+    private fun GoalCategory.toColorRes(): Int = when (this) {
+        GoalCategory.MIND -> R.color.analytics_mind
+        GoalCategory.BODY -> R.color.analytics_body
+        GoalCategory.CAREER -> R.color.analytics_career
+        GoalCategory.MONEY -> R.color.analytics_money
+        GoalCategory.SOCIAL -> R.color.analytics_social
+        GoalCategory.OTHER -> R.color.analytics_other
+    }
+
+    private fun GoalCategory.toDisplayName(): String {
+        val lowercase = name.lowercase(Locale.getDefault())
+        return lowercase.replaceFirstChar { character ->
+            if (character.isLowerCase()) character.titlecase(Locale.getDefault()) else character.toString()
+        }
+    }
 }

--- a/app/src/main/java/be/buithg/supergoal/presentation/ui/analytic/AnalyticViewModel.kt
+++ b/app/src/main/java/be/buithg/supergoal/presentation/ui/analytic/AnalyticViewModel.kt
@@ -1,0 +1,101 @@
+package be.buithg.supergoal.presentation.ui.analytic
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import be.buithg.supergoal.domain.model.Goal
+import be.buithg.supergoal.domain.model.GoalCategory
+import be.buithg.supergoal.domain.usecase.GoalUseCases
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlin.math.roundToInt
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+
+@HiltViewModel
+class AnalyticViewModel @Inject constructor(
+    goalUseCases: GoalUseCases,
+) : ViewModel() {
+
+    val uiState: StateFlow<AnalyticUiState> = goalUseCases.observeGoals()
+        .map(::toUiState)
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5_000),
+            initialValue = AnalyticUiState(),
+        )
+
+    private fun toUiState(goals: List<Goal>): AnalyticUiState {
+        val totalSubGoals = goals.sumOf { it.subGoals.size }
+        val completedSubGoals = goals.sumOf { goal -> goal.subGoals.count { subGoal -> subGoal.isCompleted } }
+
+        val hasOverallProgress = totalSubGoals > 0
+        val overallProgressPercentage = if (hasOverallProgress) {
+            ((completedSubGoals.toDouble() / totalSubGoals.toDouble()) * 100).roundToInt()
+        } else {
+            0
+        }
+
+        val shares = goals
+            .filter(Goal::isCompleted)
+            .mapNotNull { goal ->
+                val endTime = goal.archivedAtMillis ?: goal.deadlineMillis
+                val duration = (endTime - goal.createdAtMillis).coerceAtLeast(0L)
+                if (duration == 0L) {
+                    null
+                } else {
+                    goal.category to duration
+                }
+            }
+            .groupBy(
+                keySelector = { (category, _) -> category },
+                valueTransform = { (_, duration) -> duration },
+            )
+            .mapNotNull { (category, durations) ->
+                val totalDuration = durations.sum()
+                if (totalDuration <= 0L) {
+                    null
+                } else {
+                    category to totalDuration
+                }
+            }
+            .let { groupedDurations ->
+                val grandTotal = groupedDurations.sumOf { (_, duration) -> duration }
+                if (grandTotal <= 0L) {
+                    emptyList()
+                } else {
+                    groupedDurations
+                        .map { (category, duration) ->
+                            val percent = (duration.toDouble() / grandTotal.toDouble()) * 100
+                            CategoryShare(
+                                category = category,
+                                percentage = percent,
+                            )
+                        }
+                        .filter { it.percentage > 0.0 }
+                        .sortedByDescending(CategoryShare::percentage)
+                }
+            }
+
+        return AnalyticUiState(
+            hasOverallProgress = hasOverallProgress,
+            overallProgress = overallProgressPercentage,
+            categoryShares = shares,
+        )
+    }
+}
+
+data class AnalyticUiState(
+    val hasOverallProgress: Boolean = false,
+    val overallProgress: Int = 0,
+    val categoryShares: List<CategoryShare> = emptyList(),
+) {
+    val hasCategoryShares: Boolean get() = categoryShares.isNotEmpty()
+    val shouldShowEmptyState: Boolean get() = !hasOverallProgress && categoryShares.isEmpty()
+}
+
+data class CategoryShare(
+    val category: GoalCategory,
+    val percentage: Double,
+)

--- a/app/src/main/java/be/buithg/supergoal/presentation/ui/custom/AnalyticsPieChartView.kt
+++ b/app/src/main/java/be/buithg/supergoal/presentation/ui/custom/AnalyticsPieChartView.kt
@@ -1,0 +1,88 @@
+package be.buithg.supergoal.presentation.ui.custom
+
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.graphics.RectF
+import android.util.AttributeSet
+import android.view.View
+import androidx.core.content.withStyledAttributes
+import be.buithg.supergoal.R
+import kotlin.math.min
+
+class AnalyticsPieChartView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0,
+) : View(context, attrs, defStyleAttr) {
+
+    private val arcRect = RectF()
+    private val paint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        style = Paint.Style.STROKE
+        strokeCap = Paint.Cap.ROUND
+    }
+
+    private var strokeWidth = dp(26f)
+    private var gapAngle = 3f
+
+    private var slices: List<Slice> = emptyList()
+
+    init {
+        context.withStyledAttributes(attrs, R.styleable.AnalyticsPieChartView) {
+            strokeWidth = getDimension(R.styleable.AnalyticsPieChartView_apc_strokeWidth, strokeWidth)
+            gapAngle = getFloat(R.styleable.AnalyticsPieChartView_apc_gapAngle, gapAngle)
+        }
+        paint.strokeWidth = strokeWidth
+    }
+
+    fun setData(fractions: List<Slice>) {
+        slices = fractions
+        invalidate()
+    }
+
+    override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+        val desiredSize = (strokeWidth * 2 + dp(120f)).toInt()
+        val width = resolveSize(desiredSize, widthMeasureSpec)
+        val height = resolveSize(desiredSize, heightMeasureSpec)
+        setMeasuredDimension(width, height)
+    }
+
+    override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
+        val contentWidth = w - paddingLeft - paddingRight
+        val contentHeight = h - paddingTop - paddingBottom
+        val size = min(contentWidth, contentHeight).toFloat()
+        val left = paddingLeft + (contentWidth - size) / 2f
+        val top = paddingTop + (contentHeight - size) / 2f
+        val padding = strokeWidth / 2f
+        arcRect.set(
+            left + padding,
+            top + padding,
+            left + size - padding,
+            top + size - padding,
+        )
+    }
+
+    override fun onDraw(canvas: Canvas) {
+        super.onDraw(canvas)
+        if (slices.isEmpty()) return
+
+        paint.strokeWidth = strokeWidth
+        var startAngle = -90f
+        slices.forEach { slice ->
+            val sweep = slice.fraction * 360f
+            if (sweep <= 0f) return@forEach
+            val segmentGap = if (sweep > gapAngle) gapAngle else 0f
+            val adjustedSweep = (sweep - segmentGap).coerceAtLeast(0f)
+            paint.color = slice.color
+            canvas.drawArc(arcRect, startAngle + segmentGap / 2f, adjustedSweep, false, paint)
+            startAngle += sweep
+        }
+    }
+
+    private fun dp(value: Float): Float = value * resources.displayMetrics.density
+
+    data class Slice(
+        val fraction: Float,
+        val color: Int,
+    )
+}

--- a/app/src/main/res/drawable/bg_analytics_legend_dot.xml
+++ b/app/src/main/res/drawable/bg_analytics_legend_dot.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <size android:width="12dp" android:height="12dp" />
+    <solid android:color="@android:color/white" />
+</shape>

--- a/app/src/main/res/drawable/bg_overall_progress_completed.xml
+++ b/app/src/main/res/drawable/bg_overall_progress_completed.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <gradient
+        android:angle="0"
+        android:endColor="@color/analytics_progress_end"
+        android:startColor="@color/analytics_progress_start" />
+    <corners
+        android:bottomLeftRadius="12dp"
+        android:bottomRightRadius="0dp"
+        android:topLeftRadius="12dp"
+        android:topRightRadius="0dp" />
+</shape>

--- a/app/src/main/res/drawable/bg_overall_progress_completed_full.xml
+++ b/app/src/main/res/drawable/bg_overall_progress_completed_full.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <gradient
+        android:angle="0"
+        android:endColor="@color/analytics_progress_end"
+        android:startColor="@color/analytics_progress_start" />
+    <corners android:radius="12dp" />
+</shape>

--- a/app/src/main/res/drawable/bg_overall_progress_remaining.xml
+++ b/app/src/main/res/drawable/bg_overall_progress_remaining.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/analytics_progress_track" />
+    <corners
+        android:bottomLeftRadius="0dp"
+        android:bottomRightRadius="12dp"
+        android:topLeftRadius="0dp"
+        android:topRightRadius="12dp" />
+</shape>

--- a/app/src/main/res/drawable/bg_overall_progress_remaining_full.xml
+++ b/app/src/main/res/drawable/bg_overall_progress_remaining_full.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/analytics_progress_track" />
+    <corners android:radius="12dp" />
+</shape>

--- a/app/src/main/res/drawable/bg_overall_progress_track.xml
+++ b/app/src/main/res/drawable/bg_overall_progress_track.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/analytics_progress_track" />
+    <corners android:radius="16dp" />
+</shape>

--- a/app/src/main/res/layout/fragment_analytic.xml
+++ b/app/src/main/res/layout/fragment_analytic.xml
@@ -1,180 +1,160 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@drawable/add_goal_bg"
+    android:paddingBottom="32dp"
     tools:context=".presentation.ui.analytic.AnalyticFragment">
 
     <LinearLayout
         android:layout_width="match_parent"
-        android:paddingTop="20dp"
+        android:layout_height="wrap_content"
         android:orientation="vertical"
-        android:layout_height="match_parent">
+        android:paddingHorizontal="20dp"
+        android:paddingTop="24dp">
 
-
-
-    <TextView
-        android:id="@+id/tvMyGoals"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="20dp"
-        android:layout_marginTop="10dp"
-        android:fontFamily="@font/poppins_extra_bold"
-        android:text="Analytics"
-        android:textAllCaps="true"
-        android:textColor="@android:color/white"
-        android:textSize="40sp" />
-
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:gravity="center"
-        android:orientation="horizontal"
-        android:paddingVertical="16dp">
-
-        <!-- All -->
         <TextView
-            android:id="@+id/btn_all"
-            android:layout_width="110dp"
-            android:layout_height="40dp"
-            android:layout_marginEnd="12dp"
-            android:gravity="center"
-            android:background="@drawable/bg_tab_selected"
-            android:text="All"
-            android:textColor="@android:color/white"
-            android:textStyle="bold"
-            android:textSize="16sp" />
-
-        <!-- Active -->
-        <TextView
-            android:id="@+id/btn_active"
-            android:layout_width="110dp"
-            android:layout_height="40dp"
-            android:layout_marginEnd="12dp"
-            android:gravity="center"
-            android:background="@drawable/bg_tab_unselected"
-            android:text="Active"
-            android:textColor="@android:color/white"
-            android:textStyle="bold"
-            android:textSize="16sp" />
-
-        <!-- Archived -->
-        <TextView
-            android:id="@+id/btn_archived"
-            android:layout_width="110dp"
-            android:layout_height="40dp"
-            android:gravity="center"
-            android:background="@drawable/bg_tab_unselected"
-            android:text="Archived"
-            android:textColor="@android:color/white"
-            android:textStyle="bold"
-            android:textSize="16sp" />
-
-    </LinearLayout>
-
-    <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Overall progress"
-        android:layout_marginStart="20dp"
-        android:textSize="16sp"
-        android:layout_marginTop="10dp"
-        android:textColor="@color/white"
-        android:fontFamily="@font/poppins_bold"/>
-
-    <!-- Здесь добавлен прогресс -->
-    <FrameLayout
-        android:layout_width="match_parent"
-        android:layout_height="260dp"
-        android:gravity="center"
-        >
-
-        <be.buithg.supergoal.presentation.ui.custom.CircularGradientProgressView
-            android:id="@+id/cgProgress"
-            android:layout_width="220dp"
-            android:layout_height="220dp"
-            android:padding="4dp"
-            android:layout_gravity="center"
-            app:cgp_progress="65"
-            app:cgp_strokeWidth="16dp"
-            app:cgp_trackColor="#242631"
-            app:cgp_startAngle="270"
-            app:cgp_gapAngle="10"
-            app:cgp_gradientStartColor="#F23230"
-            app:cgp_gradientEndColor="#8C1D1C"/>
-
-        <LinearLayout
+            android:id="@+id/tvTitle"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:orientation="vertical"
-            android:layout_gravity="center"
-            android:gravity="center">
+            android:fontFamily="@font/poppins_extra_bold"
+            android:text="@string/analytics_screen_title"
+            android:textAllCaps="true"
+            android:textColor="@android:color/white"
+            android:textSize="32sp" />
+
+        <TextView
+            android:id="@+id/tvOverallHeader"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:fontFamily="@font/poppins_bold"
+            android:text="@string/analytics_overall_progress_title"
+            android:textColor="@android:color/white"
+            android:textSize="18sp" />
+
+        <LinearLayout
+            android:id="@+id/overallContainer"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:orientation="vertical">
+
+            <LinearLayout
+                android:id="@+id/overallProgressBar"
+                android:layout_width="match_parent"
+                android:layout_height="48dp"
+                android:background="@drawable/bg_overall_progress_track"
+                android:clipToPadding="false"
+                android:clipToOutline="true"
+                android:gravity="center_vertical"
+                android:orientation="horizontal"
+                android:padding="4dp">
+
+                <FrameLayout
+                    android:id="@+id/overallProgressCompletedSegment"
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_weight="1"
+                    android:background="@drawable/bg_overall_progress_completed"
+                    android:paddingStart="16dp"
+                    android:paddingEnd="8dp">
+
+                    <TextView
+                        android:id="@+id/tvOverallPercent"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center_vertical"
+                        android:fontFamily="@font/poppins_bold"
+                        android:textColor="@android:color/white"
+                        android:textSize="16sp"
+                        tools:text="72%" />
+                </FrameLayout>
+
+                <FrameLayout
+                    android:id="@+id/overallProgressRemainingSegment"
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_weight="1"
+                    android:background="@drawable/bg_overall_progress_remaining"
+                    android:paddingStart="8dp"
+                    android:paddingEnd="16dp">
+
+                    <TextView
+                        android:id="@+id/tvOverallRemainingPercent"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center_vertical|end"
+                        android:fontFamily="@font/poppins_bold"
+                        android:textColor="@android:color/white"
+                        android:textSize="16sp"
+                        tools:text="28%" />
+                </FrameLayout>
+            </LinearLayout>
 
             <TextView
-                android:id="@+id/tvCenterPercent"
+                android:id="@+id/tvOverallSubtitle"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="65%"
-                android:textColor="@android:color/white"
-                android:textSize="36sp"
-                android:textStyle="bold"
-                android:fontFamily="@font/poppins_extra_bold"/>
-
-            <TextView
-                android:id="@+id/tvCenterSubtitle"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="Completed goals"
+                android:layout_marginTop="8dp"
+                android:fontFamily="@font/poppins_regular"
+                android:text="@string/analytics_overall_progress_subtitle"
                 android:textColor="#9E9EA6"
-                android:textSize="14sp"
-                android:fontFamily="@font/poppins_regular"/>
+                android:textSize="14sp" />
         </LinearLayout>
 
-    </FrameLayout>
+        <TextView
+            android:id="@+id/tvOverallEmpty"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:fontFamily="@font/poppins_regular"
+            android:gravity="center"
+            android:text="@string/analytics_empty_state"
+            android:textColor="@android:color/white"
+            android:textSize="16sp"
+            android:visibility="gone"
+            tools:visibility="gone" />
 
-    <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Completion percentage by categories"
-        android:textColor="@color/white"
-        android:textSize="16sp"
-        android:fontFamily="@font/poppins_bold"
-        android:layout_marginTop="16dp"
-        android:layout_marginStart="20dp"/>
+        <TextView
+            android:id="@+id/tvCategoriesHeader"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="28dp"
+            android:fontFamily="@font/poppins_bold"
+            android:text="@string/analytics_category_distribution_title"
+            android:textColor="@android:color/white"
+            android:textSize="18sp" />
 
-    <!-- Контейнер для категорий -->
-    <LinearLayout
-        android:id="@+id/categoryContainer"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="vertical"
-        android:layout_marginTop="12dp"
-        android:layout_marginHorizontal="20dp">
+        <be.buithg.supergoal.presentation.ui.custom.AnalyticsPieChartView
+            android:id="@+id/pieChartView"
+            android:layout_width="match_parent"
+            android:layout_height="240dp"
+            android:layout_marginTop="16dp"
+            android:paddingHorizontal="12dp"
+            tools:ignore="MissingConstraints" />
 
-        <!-- Category 1 -->
-        <include
-            layout="@layout/item_category_progress"
-            android:id="@+id/itemFitness"/>
+        <LinearLayout
+            android:id="@+id/legendContainer"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:orientation="vertical" />
 
-        <!-- Category 2 -->
-        <include
-            layout="@layout/item_category_progress"
-            android:id="@+id/itemTeam"/>
-
-        <!-- Category 3 -->
-        <include
-            layout="@layout/item_category_progress"
-            android:id="@+id/itemIndividual"/>
-
-        <!-- Category 4 -->
-        <include
-            layout="@layout/item_category_progress"
-            android:id="@+id/itemOther"/>
-
-    </LinearLayout>
-
+        <TextView
+            android:id="@+id/tvPieEmpty"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:fontFamily="@font/poppins_regular"
+            android:gravity="center"
+            android:text="@string/analytics_empty_state"
+            android:textColor="@android:color/white"
+            android:textSize="16sp"
+            android:visibility="gone"
+            tools:visibility="gone" />
 
     </LinearLayout>
 

--- a/app/src/main/res/layout/item_analytics_legend.xml
+++ b/app/src/main/res/layout/item_analytics_legend.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginBottom="8dp"
+    android:gravity="center_vertical"
+    android:orientation="horizontal">
+
+    <View
+        android:id="@+id/vLegendColor"
+        android:layout_width="12dp"
+        android:layout_height="12dp"
+        android:layout_marginEnd="12dp"
+        android:background="@drawable/bg_analytics_legend_dot" />
+
+    <TextView
+        android:id="@+id/tvLegendTitle"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:fontFamily="@font/poppins_regular"
+        android:textColor="@android:color/white"
+        android:textSize="16sp"
+        android:maxLines="1"
+        android:ellipsize="end"
+        android:text="Mind" />
+
+    <TextView
+        android:id="@+id/tvLegendPercent"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:fontFamily="@font/poppins_medium"
+        android:textColor="@android:color/white"
+        android:textSize="16sp"
+        android:layout_marginStart="12dp"
+        android:text="40%" />
+
+</LinearLayout>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -8,4 +8,9 @@
         <attr name="cgp_gradientStartColor" format="color"/>
         <attr name="cgp_gradientEndColor" format="color"/>
     </declare-styleable>
+
+    <declare-styleable name="AnalyticsPieChartView">
+        <attr name="apc_strokeWidth" format="dimension"/>
+        <attr name="apc_gapAngle" format="float"/>
+    </declare-styleable>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -2,4 +2,13 @@
 <resources>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
+    <color name="analytics_progress_start">#F23230</color>
+    <color name="analytics_progress_end">#8C1D1C</color>
+    <color name="analytics_progress_track">#3A3D4C</color>
+    <color name="analytics_mind">#FF8A80</color>
+    <color name="analytics_body">#4DD0E1</color>
+    <color name="analytics_career">#FDD835</color>
+    <color name="analytics_money">#81C784</color>
+    <color name="analytics_social">#BA68C8</color>
+    <color name="analytics_other">#90A4AE</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -37,4 +37,12 @@
     <string name="action_delete">Delete</string>
     <string name="action_confirm">Confirm</string>
     <string name="toast_goal_deleted">Goal is successfully deleted</string>
+
+    <!-- Analytics -->
+    <string name="analytics_screen_title">GOALS ANALYTICS</string>
+    <string name="analytics_overall_progress_title">Overall progress</string>
+    <string name="analytics_overall_progress_subtitle">Completed marks</string>
+    <string name="analytics_category_distribution_title">Time distribution by category</string>
+    <string name="analytics_empty_state">No data for analytics graph</string>
+    <string name="analytics_percent_value">%1$d%%</string>
 </resources>


### PR DESCRIPTION
## Summary
- replace the analytics overall circular indicator with a segmented horizontal bar matching the provided reference
- create gradient and track drawables plus color updates to render the completed and remaining portions cleanly
- update the fragment binding logic to size the new segments, toggle empty states, and display both completed and remaining percentages

## Testing
- `./gradlew lint` *(fails: SDK location not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5a31b0824832aab00779c11be7655