### PR TITLE
Implement challenge list UI

### DIFF
--- a/app/src/main/java/be/buithg/supergoal/presentation/ui/challenges/Challenge.kt
+++ b/app/src/main/java/be/buithg/supergoal/presentation/ui/challenges/Challenge.kt
@@ -1,0 +1,15 @@
+package be.buithg.supergoal.presentation.ui.challenges
+
+import androidx.annotation.DrawableRes
+
+/**
+ * Represents a pre-defined challenge that users can adopt as a goal.
+ */
+data class Challenge(
+    val id: Int,
+    val title: String,
+    val category: String,
+    val durationDays: Int,
+    val subgoals: List<String>,
+    @DrawableRes val imageRes: Int,
+)

--- a/app/src/main/java/be/buithg/supergoal/presentation/ui/challenges/ChallengeAdapter.kt
+++ b/app/src/main/java/be/buithg/supergoal/presentation/ui/challenges/ChallengeAdapter.kt
@@ -1,0 +1,52 @@
+package be.buithg.supergoal.presentation.ui.challenges
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import be.buithg.supergoal.R
+import be.buithg.supergoal.databinding.ChallengeItemBinding
+
+class ChallengeAdapter(
+    private val onChallengeClick: (Challenge) -> Unit,
+) : ListAdapter<Challenge, ChallengeAdapter.ChallengeViewHolder>(DiffCallback) {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ChallengeViewHolder {
+        val inflater = LayoutInflater.from(parent.context)
+        val binding = ChallengeItemBinding.inflate(inflater, parent, false)
+        return ChallengeViewHolder(binding, onChallengeClick)
+    }
+
+    override fun onBindViewHolder(holder: ChallengeViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+
+    class ChallengeViewHolder(
+        private val binding: ChallengeItemBinding,
+        private val onChallengeClick: (Challenge) -> Unit,
+    ) : RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(item: Challenge) = with(binding) {
+            ivCover.setImageResource(item.imageRes)
+            tvTitle.text = item.title
+            tvCategory.text = root.context.getString(R.string.challenge_category_format, item.category)
+            tvCompletionTime.text = root.resources.getQuantityString(
+                R.plurals.challenge_completion_time,
+                item.durationDays,
+                item.durationDays,
+            )
+
+            root.setOnClickListener { onChallengeClick(item) }
+            btnAddGoal.setOnClickListener { onChallengeClick(item) }
+        }
+    }
+
+    private object DiffCallback : DiffUtil.ItemCallback<Challenge>() {
+        override fun areItemsTheSame(oldItem: Challenge, newItem: Challenge): Boolean =
+            oldItem.id == newItem.id
+
+        override fun areContentsTheSame(oldItem: Challenge, newItem: Challenge): Boolean =
+            oldItem == newItem
+    }
+}

--- a/app/src/main/java/be/buithg/supergoal/presentation/ui/challenges/ChallengeDataSource.kt
+++ b/app/src/main/java/be/buithg/supergoal/presentation/ui/challenges/ChallengeDataSource.kt
@@ -1,0 +1,84 @@
+package be.buithg.supergoal.presentation.ui.challenges
+
+import be.buithg.supergoal.R
+
+object ChallengeDataSource {
+
+    fun getChallenges(): List<Challenge> = listOf(
+        Challenge(
+            id = 1,
+            title = "Sunrise Scan",
+            category = "Body",
+            durationDays = 7,
+            subgoals = dailyTasks("Drink 2 litres water", 7),
+            imageRes = R.drawable.ball_ic,
+        ),
+        Challenge(
+            id = 2,
+            title = "Inbox Zero-ish",
+            category = "Social",
+            durationDays = 7,
+            subgoals = dailyTasks("Clear five emails", 7),
+            imageRes = R.drawable.ball_ic,
+        ),
+        Challenge(
+            id = 3,
+            title = "Micro-Workout",
+            category = "Body",
+            durationDays = 14,
+            subgoals = dailyTasks("5 minutes of movement", 14),
+            imageRes = R.drawable.ball_ic,
+        ),
+        Challenge(
+            id = 4,
+            title = "Budget Breath",
+            category = "Money",
+            durationDays = 14,
+            subgoals = dailyTasks("Track one expense line per day", 14),
+            imageRes = R.drawable.ball_ic,
+        ),
+        Challenge(
+            id = 5,
+            title = "Deep Work Dot",
+            category = "Career",
+            durationDays = 14,
+            subgoals = dailyTasks("10 focus minutes with a timer", 14),
+            imageRes = R.drawable.ball_ic,
+        ),
+        Challenge(
+            id = 6,
+            title = "Digital Sunset",
+            category = "Mind",
+            durationDays = 30,
+            subgoals = dailyTasks("Screens off 1 hour before bed", 30),
+            imageRes = R.drawable.ball_ic,
+        ),
+        Challenge(
+            id = 7,
+            title = "Gratitude Ping",
+            category = "Mind",
+            durationDays = 30,
+            subgoals = dailyTasks("Write one thankful line", 30),
+            imageRes = R.drawable.ball_ic,
+        ),
+        Challenge(
+            id = 8,
+            title = "Craft Corner",
+            category = "Other",
+            durationDays = 30,
+            subgoals = dailyTasks("Touch your craft for 10 minutes", 30),
+            imageRes = R.drawable.ball_ic,
+        ),
+        Challenge(
+            id = 9,
+            title = "Language Leaf",
+            category = "Other",
+            durationDays = 30,
+            subgoals = dailyTasks("Learn 5 new words daily", 30),
+            imageRes = R.drawable.ball_ic,
+        ),
+    )
+
+    private fun dailyTasks(description: String, days: Int): List<String> =
+        List(days) { index -> "$description (day ${index + 1})" }
+}

--- a/app/src/main/java/be/buithg/supergoal/presentation/ui/challenges/ChallengeFragment.kt
+++ b/app/src/main/java/be/buithg/supergoal/presentation/ui/challenges/ChallengeFragment.kt
@@ -1,60 +1,54 @@
 package be.buithg.supergoal.presentation.ui.challenges
 
 import android.os.Bundle
-import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.os.bundleOf
+import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.findNavController
+import androidx.recyclerview.widget.LinearLayoutManager
 import be.buithg.supergoal.R
+import be.buithg.supergoal.databinding.FragmentChallengeBinding
 
-// TODO: Rename parameter arguments, choose names that match
-// the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
-private const val ARG_PARAM1 = "param1"
-private const val ARG_PARAM2 = "param2"
-
-/**
- * A simple [Fragment] subclass.
- * Use the [ChallengeFragment.newInstance] factory method to
- * create an instance of this fragment.
- */
 class ChallengeFragment : Fragment() {
-    // TODO: Rename and change types of parameters
-    private var param1: String? = null
-    private var param2: String? = null
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        arguments?.let {
-            param1 = it.getString(ARG_PARAM1)
-            param2 = it.getString(ARG_PARAM2)
+    private var _binding: FragmentChallengeBinding? = null
+    private val binding get() = _binding!!
+
+    private lateinit var challengeAdapter: ChallengeAdapter
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        _binding = FragmentChallengeBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setupRecyclerView()
+        challengeAdapter.submitList(ChallengeDataSource.getChallenges())
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        binding.rvChallenges.adapter = null
+        _binding = null
+    }
+
+    private fun setupRecyclerView() {
+        challengeAdapter = ChallengeAdapter(onChallengeClick = ::openChallengeDetails)
+        binding.rvChallenges.apply {
+            layoutManager = LinearLayoutManager(requireContext())
+            adapter = challengeAdapter
         }
     }
 
-    override fun onCreateView(
-        inflater: LayoutInflater, container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View? {
-        // Inflate the layout for this fragment
-        return inflater.inflate(R.layout.fragment_challenge, container, false)
-    }
-
-    companion object {
-        /**
-         * Use this factory method to create a new instance of
-         * this fragment using the provided parameters.
-         *
-         * @param param1 Parameter 1.
-         * @param param2 Parameter 2.
-         * @return A new instance of fragment ChallengeFragment.
-         */
-        // TODO: Rename and change types and number of parameters
-        @JvmStatic
-        fun newInstance(param1: String, param2: String) =
-            ChallengeFragment().apply {
-                arguments = Bundle().apply {
-                    putString(ARG_PARAM1, param1)
-                    putString(ARG_PARAM2, param2)
-                }
-            }
+    private fun openChallengeDetails(challenge: Challenge) {
+        val arguments = bundleOf("challengeId" to challenge.id)
+        findNavController().navigate(R.id.challengeDetailFragment, arguments)
     }
 }

--- a/app/src/main/res/layout/challenge_item.xml
+++ b/app/src/main/res/layout/challenge_item.xml
@@ -7,17 +7,17 @@
     android:background="@drawable/bg_goal_item"
     android:paddingEnd="16dp">
 
-    <!-- Обложка цели (квадрат с закруглениями) -->
     <com.google.android.material.imageview.ShapeableImageView
         android:id="@+id/ivCover"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:contentDescription="@string/app_name"
-        android:paddingVertical="10dp"
         android:paddingStart="10dp"
+        android:paddingTop="10dp"
         android:paddingEnd="5dp"
+        android:paddingBottom="10dp"
         android:scaleType="centerCrop"
-        android:src="@drawable/ic_launcher_background"
+        android:src="@drawable/ball_ic"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintDimensionRatio="1:1"
         app:layout_constraintStart_toStartOf="parent"
@@ -26,7 +26,16 @@
         app:strokeColor="#F23230"
         app:strokeWidth="2dp" />
 
-    <!-- Заголовок цели -->
+    <ImageView
+        android:id="@+id/ivChevron"
+        android:layout_width="20dp"
+        android:layout_height="20dp"
+        android:layout_marginTop="20dp"
+        android:layout_marginEnd="5dp"
+        android:src="@drawable/play_ic"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
     <TextView
         android:id="@+id/tvTitle"
         android:layout_width="0dp"
@@ -41,78 +50,59 @@
         android:textColor="@android:color/white"
         android:textSize="16sp"
         android:textStyle="bold"
-        app:layout_constraintEnd_toStartOf="@+id/imageView"
+        app:layout_constraintEnd_toStartOf="@id/ivChevron"
         app:layout_constraintStart_toEndOf="@id/ivCover"
         app:layout_constraintTop_toTopOf="@id/ivCover"
         tools:text="Win Championship Trophy" />
 
-    <!-- Процент справа (красный) -->
-
-    <!-- Категория/подзаголовок -->
-
-
-    <!-- Прогресс-бар -->
-
-    <!-- Дата дедлайна -->
     <TextView
-        android:id="@+id/tvDeadline"
+        android:id="@+id/tvCategory"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="12dp"
-        android:elevation="1dp"
-        android:ellipsize="end"
+        android:layout_marginTop="8dp"
         android:fontFamily="@font/poppins_regular"
-        android:gravity="start|center_vertical"
-        android:inputType="textMultiLine"
-        android:scrollHorizontally="false"
-        android:singleLine="false"
-        android:text="Body"
         android:textColor="#8FFFFFFF"
-        android:textSize="16sp"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@+id/ivCover"
-        app:layout_constraintTop_toBottomOf="@+id/tvTitle" />
+        android:textSize="14sp"
+        app:layout_constraintEnd_toStartOf="@id/ivChevron"
+        app:layout_constraintStart_toEndOf="@id/ivCover"
+        app:layout_constraintTop_toBottomOf="@id/tvTitle"
+        tools:text="Category: Body" />
 
     <TextView
-        android:id="@+id/tvTime"
+        android:id="@+id/tvCompletionTime"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:elevation="1dp"
         android:layout_marginStart="12dp"
-        android:ellipsize="end"
+        android:layout_marginTop="4dp"
+        android:layout_marginEnd="12dp"
+        android:layout_marginBottom="16dp"
         android:fontFamily="@font/poppins_regular"
-        android:gravity="start|center_vertical"
-        android:inputType="textMultiLine"
-        android:scrollHorizontally="false"
-        android:singleLine="false"
-        android:text="Body"
-        android:layout_marginBottom="15dp"
         android:textColor="#8FFFFFFF"
-        android:textSize="16sp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@+id/materialButton"
-        app:layout_constraintStart_toEndOf="@+id/ivCover"
-        tools:text="7 days" />
-
-    <ImageView
-        android:id="@+id/imageView"
-        android:layout_width="20dp"
-        android:layout_height="20dp"
-        android:layout_marginTop="20dp"
-        android:layout_marginEnd="5dp"
-        android:src="@drawable/play_ic"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        android:textSize="14sp"
+        app:layout_constraintBottom_toBottomOf="@id/ivCover"
+        app:layout_constraintEnd_toStartOf="@id/btnAddGoal"
+        app:layout_constraintStart_toEndOf="@id/ivCover"
+        app:layout_constraintTop_toBottomOf="@id/tvCategory"
+        tools:text="7-day challenge" />
 
     <com.google.android.material.button.MaterialButton
-        android:id="@+id/materialButton"
+        android:id="@+id/btnAddGoal"
+        style="@style/Widget.MaterialComponents.Button.TextButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginBottom="10dp"
         android:backgroundTint="#F23230"
         android:fontFamily="@font/poppins_bold"
-        android:paddingVertical="5dp"
-        android:text="Add Goal"
+        android:minHeight="0dp"
+        android:paddingHorizontal="16dp"
+        android:paddingVertical="6dp"
+        android:text="@string/challenge_add_goal"
+        android:textAllCaps="false"
+        android:textColor="@android:color/white"
+        android:textSize="14sp"
+        app:cornerRadius="16dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_challenge.xml
+++ b/app/src/main/res/layout/fragment_challenge.xml
@@ -1,86 +1,41 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@drawable/add_goal_bg"
+    android:paddingVertical="32dp"
     tools:context=".presentation.ui.challenges.ChallengeFragment">
 
+    <TextView
+        android:id="@+id/tvHeading"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="24dp"
+        android:layout_marginEnd="24dp"
+        android:fontFamily="@font/poppins_extra_bold"
+        android:text="@string/challenge_heading"
+        android:textAllCaps="true"
+        android:textColor="@android:color/white"
+        android:textSize="36sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:paddingTop="20dp"
-        android:orientation="vertical"
-        android:layout_height="match_parent">
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/rvChallenges"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginStart="24dp"
+        android:layout_marginTop="24dp"
+        android:layout_marginEnd="24dp"
+        android:clipToPadding="false"
+        android:paddingBottom="32dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tvHeading"
+        tools:listitem="@layout/challenge_item" />
 
-
-
-
-        <TextView
-            android:id="@+id/tvMyGoals"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="20dp"
-            android:layout_marginTop="10dp"
-            android:fontFamily="@font/poppins_extra_bold"
-            android:textAllCaps="true"
-            android:text="Challenge"
-            android:textColor="@android:color/white"
-            android:textSize="40sp" />
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:gravity="center"
-            android:orientation="horizontal"
-            android:paddingVertical="16dp">
-
-            <!-- All -->
-            <TextView
-                android:id="@+id/btn_all"
-                android:layout_width="110dp"
-                android:layout_height="40dp"
-                android:layout_marginEnd="12dp"
-                android:gravity="center"
-                android:background="@drawable/bg_tab_selected"
-                android:text="All"
-                android:textColor="@android:color/white"
-                android:textStyle="bold"
-                android:textSize="16sp" />
-
-            <!-- Active -->
-            <TextView
-                android:id="@+id/btn_active"
-                android:layout_width="110dp"
-                android:layout_height="40dp"
-                android:layout_marginEnd="12dp"
-                android:gravity="center"
-                android:background="@drawable/bg_tab_unselected"
-                android:text="Active"
-                android:textColor="@android:color/white"
-                android:textStyle="bold"
-                android:textSize="16sp" />
-
-            <!-- Archived -->
-            <TextView
-                android:id="@+id/btn_archived"
-                android:layout_width="110dp"
-                android:layout_height="40dp"
-                android:gravity="center"
-                android:background="@drawable/bg_tab_unselected"
-                android:text="Archived"
-                android:textColor="@android:color/white"
-                android:textStyle="bold"
-                android:textSize="16sp" />
-
-        </LinearLayout>
-
-        <androidx.recyclerview.widget.RecyclerView
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_marginHorizontal="20dp"/>
-    </LinearLayout>
-
-</ScrollView>
-
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -88,5 +88,10 @@
         android:id="@+id/challengeDetailFragment"
         android:name="be.buithg.supergoal.presentation.ui.challenges.ChallengeDetailFragment"
         android:label="fragment_challenge_detail"
-        tools:layout="@layout/fragment_challenge_detail" />
+        tools:layout="@layout/fragment_challenge_detail">
+        <argument
+            android:name="challengeId"
+            app:argType="integer"
+            android:defaultValue="-1" />
+    </fragment>
 </navigation>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -45,4 +45,13 @@
     <string name="analytics_category_distribution_title">Time distribution by category</string>
     <string name="analytics_empty_state">No data for analytics graph</string>
     <string name="analytics_percent_value">%1$d%%</string>
+
+    <!-- Challenges -->
+    <string name="challenge_heading">Motivation</string>
+    <string name="challenge_add_goal">Add Goal</string>
+    <string name="challenge_category_format">Category: %1$s</string>
+    <plurals name="challenge_completion_time">
+        <item quantity="one">%1$d-day challenge</item>
+        <item quantity="other">%1$d-day challenge</item>
+    </plurals>
 </resources>


### PR DESCRIPTION
## Summary
- replace the placeholder ChallengeFragment with a recycler-driven Motivation screen
- add a Challenge data source and adapter that render predefined soccer-themed goals
- refresh layouts, strings, and navigation to support challenge selection and detail routing

## Testing
- ./gradlew lint *(fails: Android SDK is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5b98282a4832aa98ddca49521227a