### PR TITLE
Implement challenge detail screen

### DIFF
--- a/app/src/main/java/be/buithg/supergoal/presentation/ui/article/Article.kt
+++ b/app/src/main/java/be/buithg/supergoal/presentation/ui/article/Article.kt
@@ -1,0 +1,8 @@
+package be.buithg.supergoal.presentation.ui.article
+
+data class Article(
+    val id: Int,
+    val title: String,
+    val coverResId: Int,
+    val content: String,
+)

--- a/app/src/main/java/be/buithg/supergoal/presentation/ui/article/ArticleAdapter.kt
+++ b/app/src/main/java/be/buithg/supergoal/presentation/ui/article/ArticleAdapter.kt
@@ -1,0 +1,36 @@
+package be.buithg.supergoal.presentation.ui.article
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import be.buithg.supergoal.databinding.ArticleItemBinding
+
+class ArticleAdapter : ListAdapter<Article, ArticleAdapter.ArticleViewHolder>(ArticleDiffCallback) {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ArticleViewHolder {
+        val inflater = LayoutInflater.from(parent.context)
+        val binding = ArticleItemBinding.inflate(inflater, parent, false)
+        return ArticleViewHolder(binding)
+    }
+
+    override fun onBindViewHolder(holder: ArticleViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+
+    class ArticleViewHolder(private val binding: ArticleItemBinding) : RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(article: Article) {
+            binding.ivCover.setImageResource(article.coverResId)
+            binding.tvTitle.text = article.title
+            binding.tvContent.text = article.content
+        }
+    }
+
+    private object ArticleDiffCallback : DiffUtil.ItemCallback<Article>() {
+        override fun areItemsTheSame(oldItem: Article, newItem: Article): Boolean = oldItem.id == newItem.id
+
+        override fun areContentsTheSame(oldItem: Article, newItem: Article): Boolean = oldItem == newItem
+    }
+}

--- a/app/src/main/java/be/buithg/supergoal/presentation/ui/article/ArticleDataSource.kt
+++ b/app/src/main/java/be/buithg/supergoal/presentation/ui/article/ArticleDataSource.kt
@@ -1,0 +1,120 @@
+package be.buithg.supergoal.presentation.ui.article
+
+import be.buithg.supergoal.R
+
+object ArticleDataSource {
+
+    fun getArticles(): List<Article> = listOf(
+        Article(
+            id = 1,
+            title = "Orion Varela: The Quiet Rise",
+            coverResId = R.drawable.article_im,
+            content = """
+                I grew up in a coastal town where the wind never rested. The ball skipped across concrete and sand, and every bounce tried to trick me. I used to believe talent was something you found, like a coin on the beach. It took me years to learn that talent is mostly repetition that refuses to be boring. On training days I arrived early and I left late. I wrote three lines after each session about one thing that went well, one thing that went wrong, and one next action I could do within twenty four hours. That habit felt small at first. Over time it became a compass. It kept me honest when praise tried to make me lazy and when criticism tried to make me small.
+                In my first professional season I did not start often. I watched more than I played. Instead of sulking I treated the bench like a classroom. I tracked the rhythm of the match and the tiny shifts in space that opened for five seconds and then closed. When the coach finally called my name I knew exactly which pockets I wanted to attack and which teammates liked an early pass. My debut goal looked like luck to the crowd. To me it was the sum of a thousand notes written after long nights.
+                If you are chasing your own goal, try this simple loop. Decide one small win before you begin. Work with full attention for a short burst. Stop and write what you learned. Then move your body for a minute, drink water, and start again. You will not feel heroic. You will feel steady. The edge appears when you are steady. People talk about fire and rage. I trust quieter forces. Routine. Sleep. Honest review. Those are the winds that shaped my rise. When pressure comes I breathe once, look for the first simple pass, and let the game grow from there. Success is not a shout. It is a pattern that becomes a story.
+            """.trimIndent(),
+        ),
+        Article(
+            id = 2,
+            title = "Amaya Rios: Failure Taught Me Timing",
+            coverResId = R.drawable.article_im,
+            content = """
+                My first trial ended in a hallway with a polite no. I cried on the bus and promised that the next time I would make the decision easy for the selectors. Not by shouting or forcing shots, but by learning timing. In football timing is kindness to your teammates. Arrive early enough to help, late enough to open the lane, quick enough to break a line. I spent months running with a metronome app in my pocket to feel tempo without looking.
+                That practice altered my career. I began to see the field like a tide. When pressure came from one side I offered the outlet on the other. When a young forward lost the ball I lifted a thumb and asked for it again. Coaches started to trust me in hard minutes because I did not panic. I moved with the match instead of fighting it.
+                Timing matters outside sport too. Your project has a pace that you can learn. The moment before a meeting, take a breath and ask what is truly needed now. Make one clear request. Suggest one next step. If someone else needs the ball, pass it with generosity. If the lane opens in front of you, drive with courage. The secret is not drama. It is attention sharpened by practice.
+                One drill helped the most. I set cones in a zigzag and ran the pattern with the ball while a teammate clapped a rhythm. I had to touch on the clap and pass on the silent beat. At first it felt silly. After a week my head was up more often and my decisions were cleaner. I learned to look for the shoulder tilt of the defender and the breathing of my striker. Perfect timing is rare, but better timing is available to anyone who is willing to listen to the game.
+                There is also timing in rest. I used to grind until my legs were heavy and my touch turned to stone. Now I schedule recovery the way I schedule training. I sleep like it is part of my job because it is. I stretch while I watch films. I book quiet time on my calendar before hard matches so I can meet pressure with space. If you only push you will lose the music that lets you move at the right moment.
+                When I look back at that first failed trial I feel gratitude. It handed me the metronome I now carry inside. I hope you find yours. Listen for the tempo of your work today. Find one move you can sync with it. Then enjoy the simple beauty of arriving exactly when you are needed.
+            """.trimIndent(),
+        ),
+        Article(
+            id = 3,
+            title = "Dario Kovec: Building Strength That Serves",
+            coverResId = R.drawable.article_im,
+            content = """
+                I was not the strongest kid. In early matches taller defenders used me like a practice cone. I hated the gym and hid from leg day. Then a veteran took me aside and said that strength is not about showing off. Strength should serve a purpose. Hold the ball so a teammate can arrive. Win a duel so the team can breathe. Protect the play when chaos tries to scatter it. That sentence changed how I trained.
+                I built a simple routine. Push. Pull. Hinge. Carry. Sprint. Nothing fancy. I tracked the weight and the rest times, and I tracked how it felt on the field. If I gained muscle but lost agility I scaled back. Within a season my game slowed down in the best way. I could wait that extra heartbeat with a defender on my back and still lay the ball off cleanly.
+                In work or study you can build the same serving strength. Ask what supports the team right now. Sometimes it is a hard task no one wants. Sometimes it is the boring check that keeps a project safe. Find one pillar habit that makes you reliable. Maybe it is an early daily review. Maybe it is a tidy repository. When pressure rises people lean on the quiet strong person who keeps shape. That can be you. Train for service. The applause will come and go. The satisfaction of being useful stays.
+                People asked me what program I followed. I kept a clean notebook and measured progress in how the ball behaved, not only in what the barbell said. Could I protect the ball with one arm and still scan the field. Could I jump once and land ready to pass. Could I absorb a push without losing balance. These tests kept my ego in its lane. I wanted function, not theater.
+                The best surprise was emotional strength. Because I trained for service I worried less about headlines. I found peace in small invisible wins. The tackle that saved a teammate from a sprint. The hold up that let our back line exhale. The block that gave a young keeper a clear catch. This kind of satisfaction is sturdy. It survives bad days and dry spells.
+                At the office or in class you can copy this mindset. Choose tools that you can maintain. Score your week by how much friction you removed for others. Take pride in calm execution. When the big moment comes you will already be strong in the only way that matters. Useful. Present. Ready.
+            """.trimIndent(),
+        ),
+        Article(
+            id = 4,
+            title = "Lika Botev: The Science of Nerves",
+            coverResId = R.drawable.article_im,
+            content = """
+                Before every big match my stomach argued with my head. I thought I needed to kill nerves. That never worked. A sports psychologist told me to treat nerves as information. Heart rate means your body is ready. Butterflies mean you care. Shaking means energy is stuck and needs a path. Once I saw nerves as signals I could design rituals to guide them.
+                I built three small practices. First I wrote a cue card with three controllables. Effort, positioning, vocal support. I read the card and nodded. Second I did box breathing for one minute and a half. In for four. Hold for four. Out for six. Hold for two. Third I jogged the touchline and said the first five names I would connect with in the opening minutes. None of this removed fear. It turned fear into focus.
+                You can design for nerves too. Before a presentation or exam write your three controllables. Breathe like you are building a bridge back to calm. Name the first people you will serve. When the moment arrives remember that pressure visits only those who have a chance to matter. Let it help you. Energy wants a job. Give it one clear task and begin. The body will follow the mind once the mind gives it a route.
+                On the bus to a derby I once felt panic rise like a wave. I stared at the floor and counted the screws on the seat in front of me. Then I remembered my cues and turned fear into a checklist. I put a hand on my ribs and let air move low. I reviewed set pieces in my head. I pictured the first safe pass. By the time we arrived I felt alert instead of frozen. We won that day and my notes said one simple sentence. Nerves showed up. I gave them a job.
+                In daily life you can borrow this approach. Do not call yourself weak for feeling pressure. Call yourself honest. Then build a ritual that fits your context. Maybe it is a glass of water, a short walk, or a few words that you say when you open your laptop. Treat rituals as friendly machines. Press a button, get calm. Over weeks the machine will grow smoother. You will trust yourself to perform even when the heart beats fast. That trust is a true competitive edge.
+            """.trimIndent(),
+        ),
+        Article(
+            id = 5,
+            title = "Nael Haddad: A Captain Learns to Listen",
+            coverResId = R.drawable.article_im,
+            content = """
+                I earned the armband young and made every early mistake a captain can make. I gave long speeches that impressed me and bored the room. I corrected people in public and watched trust drain from their faces. A mentor taught me to listen with posture. Face people. Quiet your phone. Ask short questions. Then ask one follow up that shows you care about the real answer.
+                On the field I switched from barking to signaling. Two fingers for a press. Palm down for calm. Thumb up for courage. People began to play freer because they knew I respected them. We still argued. We just argued like people on the same side. Results improved because the team felt safe enough to be honest.
+                In any role of leadership remember that the room hears your emotion louder than your words. Set the tone with your body. Practice short clear messages. Praise specifics. When correction is needed, do it privately and end with one action the person can try next. Listening is a force. It turns raw effort into alignment. It turns talent into a team.
+                We created a rule for meetings. Everyone speaks once before anyone speaks twice. The quiet analyst began to contribute insights that changed games. The young striker started to ask for specific service rather than vague hope. I learned that my job as captain was not to be the star of the room. My job was to make sure the room became a team.
+                Leadership also means carrying weight when things go wrong. After a heavy loss I collect the first interviews so my teammates can breathe. I own our mistakes in public and I use simple language that does not throw anyone under the bus. Inside the club I turn to solutions. One clip to learn from. One drill to adjust. One conversation to clear the air.
+                If you want to lead, start small. Be early. Keep your word. Write clean messages. Ask for feedback and thank people for giving it. When you make a call, make it for the group rather than for your image. Over time trust grows. With trust the group can reach levels that talent alone cannot touch.
+            """.trimIndent(),
+        ),
+        Article(
+            id = 6,
+            title = "Suri Okafor: Crafting a Signature Move",
+            coverResId = R.drawable.article_im,
+            content = """
+                As a young winger I copied everyone. Step overs from one idol. Cut inside shots from another. The mix looked busy and produced little. A veteran coach told me to craft one signature move that fit my body and habits. I spent a summer finding it. First touch inside with the right sole, glide across the defender, then a pass rolled between the lines before the back line recovers. Simple. Repeatable. Mine.
+                Once I had a signature I stopped thinking and started reading. I looked up before the ball arrived to see the space. I asked fullbacks how they liked to receive. My training cut in half and my output doubled because my choices got cleaner.
+                In creative work the same idea applies. You do not need a thousand tricks. You need one sequence that you trust. Discover it by filming short sprints and reviewing them. Note when you feel light and when results appear. Then practice that pattern until you can run it on a tired day. A signature move does not trap you. It frees you to improvise from a strong base. People begin to recognize your touch. You begin to recognize yourself.
+                To sharpen the move I ran a constraint game. The field was half size and I could only use two touches. At first I lost the ball often. Within days my body learned to shape the first touch into a glide that set up the pass. I filmed ten reps and reviewed them with a friend. We spoke about ankles and hips and the moment to lift my eyes. No fancy effects. Just patient craft.
+                Once a week I played a street match with kids who dribble for joy. They reminded me that craft lives for play. My move grew stronger because it stayed connected to fun. In tech or art or study you will do your best work when you pair discipline with play. Build the pattern that pays your rent. Keep a space where you experiment like a child. Together they keep your spirit alive and your results reliable.
+            """.trimIndent(),
+        ),
+        Article(
+            id = 7,
+            title = "Bruno Kaito: The Long Road Back",
+            coverResId = R.drawable.article_im,
+            content = """
+                A knee injury erased a season and stole my confidence. Rehab is lonely. Progress hides behind tiny numbers and careful steps. I wanted to skip chapters. My physio smiled and said that healing keeps its own calendar. I made peace with slow days by building a scoreboard I could win. Sleep on time. Protein at each meal. Mobility before breakfast. Five honest minutes of ball work. Check marks fed motivation. Motivation fed patience.
+                When I returned I was not the same player. I was smarter. I knew when to close and when to shade. I learned to value angles as much as raw speed. The comeback taught me that identity should sit on behaviors rather than labels. If I can act like a pro each day, then I am one, no matter the minutes on the pitch.
+                If you are on a long road back from any setback choose behaviors that prove your story to yourself. Guard your sleep like treasure. Eat like your future depends on it. Work short and often. Celebrate boring wins. Start conversations with people who lift you. Resilience is not loud. It is a quiet refusal to quit paired with a plan that fits on one page. Keep that page close and walk it line by line.
+                I also learned to talk to myself with care. The first voice in my head used to be harsh. After injury I changed the script. I spoke like a calm coach who cares. This was not fake positivity. It was practical. Harsh words tightened my body and slowed healing. Kind words kept me engaged with the plan.
+                Community mattered too. I found one teammate who texted me after each appointment and one friend outside football who kept me laughing. Pick your people on purpose. Let them see your plan. Ask them to hold you to it.
+                When I finally scored again I did not explode. I smiled and tapped my knee twice in thanks. I had learned that the long road can be a gift. It strips away noise and leaves you with what is real. Your work. Your values. Your circle. Take those with you and you can face any season.
+            """.trimIndent(),
+        ),
+        Article(
+            id = 8,
+            title = "Mirela Stan: Winning With Curiosity",
+            coverResId = R.drawable.article_im,
+            content = """
+                I used to think winning was about certainty. Then I met a coach who asked more questions than he gave answers. He turned me into a student of the game. After each match I noted three patterns I had not seen before. I asked defenders what movements annoyed them. I asked keepers what shots felt hardest to read. Curiosity widened my view until I could sense options without looking directly at them.
+                Curiosity also made me kinder. When you ask, you learn what teammates carry from home or school. You plan training with empathy. You forgive faster. We won more not because we shouted more, but because we understood more.
+                For your own goals try a curiosity sprint. For one week write down one question each morning about your craft. Spend fifteen minutes exploring it. Share one insight with a colleague. Repeat. Questions do not slow you. They point you toward leverage. Victory belongs to learners. The world changes. Curiosity keeps you changing with it.
+                Curiosity thrives on structure. I keep a small template in my phone. Question of the day. Experiment. Result. Next action. I fill it in during lunch. Sometimes the experiment is tiny, like trying a different run in the box. Sometimes it is a conversation with a coach from another sport. The point is to keep the muscle alive.
+                Curiosity can also protect you from ego. When you approach a challenge as a student you give yourself permission to grow. You stop pretending to know and start discovering. This posture improves teams. Meetings turn into labs. Reviews turn into lessons. Progress speeds up because people share information instead of guarding it.
+                Try it for a month. You will feel lighter and you will probably win more. The world rewards the player who keeps asking good questions.
+            """.trimIndent(),
+        ),
+        Article(
+            id = 9,
+            title = "Yahir Qadir: Playing the Long Season",
+            coverResId = R.drawable.article_im,
+            content = """
+                My club once faced a season that would test any heart. Travel, fixtures, injuries, and a title race that swung like a pendulum. I survived by thinking in cycles rather than in moods. Three match blocks. Review. Adjust. Repeat. I set personal targets that were within my control. Win aerials. Sprint recovery runs on time. Communicate early. I treated each block as a mini season with a tiny celebration at the end. This gave me fresh starts without throwing away lessons.
+                In life you can design the same cadence. Work in cycles that end with reflection. Keep one simple log with three columns. Energy. Output. Notes. After two months you will spot patterns that feelings hide. Protect what makes you strong. Replace what drags. People imagine champions as constant flames. I think we are more like campfires that are tended with care. Add fuel. Shield from wind. Let embers rest so they can burn again. The long season rewards the person who learns how to renew.
+                I kept a small card in my bag with three reminders. Control what you can. Respect recovery. Start again now. When results stung I read the card and looked at film with clear eyes. I learned that the story of a season is a story of renewals. You do not need to be perfect. You need to return to your plan faster than doubt can grow.
+                At home I built small rituals that signaled a reset. I cooked a simple meal after a loss and called my sister. I cleaned my boots until they looked new. I wrote one line in a journal about what the match taught me. These rituals hold me together when the table is tight and the stakes feel heavy. They can hold you too.
+                Design a long season that you can love. Put recovery on the calendar. Put joy on the calendar. Protect the people who help you stay human. Results will follow a person who can keep showing up with a clear mind and a steady heart.
+            """.trimIndent(),
+        ),
+    )
+}

--- a/app/src/main/java/be/buithg/supergoal/presentation/ui/article/ArticleFragment.kt
+++ b/app/src/main/java/be/buithg/supergoal/presentation/ui/article/ArticleFragment.kt
@@ -5,21 +5,42 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
-import be.buithg.supergoal.R
+import androidx.recyclerview.widget.LinearLayoutManager
 import be.buithg.supergoal.databinding.FragmentArticleBinding
-
 
 class ArticleFragment : Fragment() {
 
-    private lateinit var binding: FragmentArticleBinding
+    private var _binding: FragmentArticleBinding? = null
+    private val binding get() = _binding!!
+
+    private lateinit var articleAdapter: ArticleAdapter
 
     override fun onCreateView(
-        inflater: LayoutInflater, container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View? {
-        binding = FragmentArticleBinding.inflate(inflater, container, false)
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        _binding = FragmentArticleBinding.inflate(inflater, container, false)
         return binding.root
     }
 
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setupRecyclerView()
+        articleAdapter.submitList(ArticleDataSource.getArticles())
+    }
 
+    override fun onDestroyView() {
+        super.onDestroyView()
+        binding.rvArticles.adapter = null
+        _binding = null
+    }
+
+    private fun setupRecyclerView() {
+        articleAdapter = ArticleAdapter()
+        binding.rvArticles.apply {
+            layoutManager = LinearLayoutManager(requireContext())
+            adapter = articleAdapter
+        }
+    }
 }

--- a/app/src/main/java/be/buithg/supergoal/presentation/ui/challenges/Challenge.kt
+++ b/app/src/main/java/be/buithg/supergoal/presentation/ui/challenges/Challenge.kt
@@ -1,0 +1,15 @@
+package be.buithg.supergoal.presentation.ui.challenges
+
+import androidx.annotation.DrawableRes
+
+/**
+ * Represents a pre-defined challenge that users can adopt as a goal.
+ */
+data class Challenge(
+    val id: Int,
+    val title: String,
+    val category: String,
+    val durationDays: Int,
+    val subgoals: List<String>,
+    @DrawableRes val imageRes: Int,
+)

--- a/app/src/main/java/be/buithg/supergoal/presentation/ui/challenges/ChallengeAdapter.kt
+++ b/app/src/main/java/be/buithg/supergoal/presentation/ui/challenges/ChallengeAdapter.kt
@@ -1,0 +1,52 @@
+package be.buithg.supergoal.presentation.ui.challenges
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import be.buithg.supergoal.R
+import be.buithg.supergoal.databinding.ChallengeItemBinding
+
+class ChallengeAdapter(
+    private val onChallengeClick: (Challenge) -> Unit,
+) : ListAdapter<Challenge, ChallengeAdapter.ChallengeViewHolder>(DiffCallback) {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ChallengeViewHolder {
+        val inflater = LayoutInflater.from(parent.context)
+        val binding = ChallengeItemBinding.inflate(inflater, parent, false)
+        return ChallengeViewHolder(binding, onChallengeClick)
+    }
+
+    override fun onBindViewHolder(holder: ChallengeViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+
+    class ChallengeViewHolder(
+        private val binding: ChallengeItemBinding,
+        private val onChallengeClick: (Challenge) -> Unit,
+    ) : RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(item: Challenge) = with(binding) {
+            ivCover.setImageResource(item.imageRes)
+            tvTitle.text = item.title
+            tvCategory.text = root.context.getString(R.string.challenge_category_format, item.category)
+            tvCompletionTime.text = root.resources.getQuantityString(
+                R.plurals.challenge_completion_time,
+                item.durationDays,
+                item.durationDays,
+            )
+
+            root.setOnClickListener { onChallengeClick(item) }
+            btnAddGoal.setOnClickListener { onChallengeClick(item) }
+        }
+    }
+
+    private object DiffCallback : DiffUtil.ItemCallback<Challenge>() {
+        override fun areItemsTheSame(oldItem: Challenge, newItem: Challenge): Boolean =
+            oldItem.id == newItem.id
+
+        override fun areContentsTheSame(oldItem: Challenge, newItem: Challenge): Boolean =
+            oldItem == newItem
+    }
+}

--- a/app/src/main/java/be/buithg/supergoal/presentation/ui/challenges/ChallengeDataSource.kt
+++ b/app/src/main/java/be/buithg/supergoal/presentation/ui/challenges/ChallengeDataSource.kt
@@ -1,0 +1,84 @@
+package be.buithg.supergoal.presentation.ui.challenges
+
+import be.buithg.supergoal.R
+
+object ChallengeDataSource {
+
+    fun getChallenges(): List<Challenge> = listOf(
+        Challenge(
+            id = 1,
+            title = "Sunrise Scan",
+            category = "Body",
+            durationDays = 7,
+            subgoals = dailyTasks("Drink 2 litres water", 7),
+            imageRes = R.drawable.challenge_screen_ic,
+        ),
+        Challenge(
+            id = 2,
+            title = "Inbox Zero-ish",
+            category = "Social",
+            durationDays = 7,
+            subgoals = dailyTasks("Clear five emails", 7),
+            imageRes = R.drawable.challenge_screen_ic,
+        ),
+        Challenge(
+            id = 3,
+            title = "Micro-Workout",
+            category = "Body",
+            durationDays = 14,
+            subgoals = dailyTasks("5 minutes of movement", 14),
+            imageRes = R.drawable.challenge_screen_ic,
+        ),
+        Challenge(
+            id = 4,
+            title = "Budget Breath",
+            category = "Money",
+            durationDays = 14,
+            subgoals = dailyTasks("Track one expense line per day", 14),
+            imageRes = R.drawable.challenge_screen_ic,
+        ),
+        Challenge(
+            id = 5,
+            title = "Deep Work Dot",
+            category = "Career",
+            durationDays = 14,
+            subgoals = dailyTasks("10 focus minutes with a timer", 14),
+            imageRes = R.drawable.challenge_screen_ic,
+        ),
+        Challenge(
+            id = 6,
+            title = "Digital Sunset",
+            category = "Mind",
+            durationDays = 30,
+            subgoals = dailyTasks("Screens off 1 hour before bed", 30),
+            imageRes = R.drawable.challenge_screen_ic,
+        ),
+        Challenge(
+            id = 7,
+            title = "Gratitude Ping",
+            category = "Mind",
+            durationDays = 30,
+            subgoals = dailyTasks("Write one thankful line", 30),
+            imageRes = R.drawable.challenge_screen_ic,
+        ),
+        Challenge(
+            id = 8,
+            title = "Craft Corner",
+            category = "Other",
+            durationDays = 30,
+            subgoals = dailyTasks("Touch your craft for 10 minutes", 30),
+            imageRes = R.drawable.challenge_screen_ic,
+        ),
+        Challenge(
+            id = 9,
+            title = "Language Leaf",
+            category = "Other",
+            durationDays = 30,
+            subgoals = dailyTasks("Learn 5 new words daily", 30),
+            imageRes = R.drawable.challenge_screen_ic,
+        ),
+    )
+
+    private fun dailyTasks(description: String, days: Int): List<String> =
+        List(days) { index -> "$description (day ${index + 1})" }
+}

--- a/app/src/main/java/be/buithg/supergoal/presentation/ui/challenges/ChallengeDetailUiState.kt
+++ b/app/src/main/java/be/buithg/supergoal/presentation/ui/challenges/ChallengeDetailUiState.kt
@@ -1,0 +1,22 @@
+package be.buithg.supergoal.presentation.ui.challenges
+
+import androidx.annotation.DrawableRes
+
+data class ChallengeDetailUiState(
+    val isLoading: Boolean = true,
+    val title: String = "",
+    val category: String = "",
+    val subGoals: List<ChallengeSubGoalUi> = emptyList(),
+    val deadlineText: String = "",
+    val durationDays: Int = 0,
+    @DrawableRes val illustrationRes: Int = 0,
+) {
+    val hasContent: Boolean get() = title.isNotBlank()
+    val isSubGoalListEmpty: Boolean get() = subGoals.isEmpty()
+}
+
+data class ChallengeSubGoalUi(
+    val id: Long,
+    val title: String,
+    val isChecked: Boolean = false,
+)

--- a/app/src/main/java/be/buithg/supergoal/presentation/ui/challenges/ChallengeDetailViewModel.kt
+++ b/app/src/main/java/be/buithg/supergoal/presentation/ui/challenges/ChallengeDetailViewModel.kt
@@ -1,0 +1,140 @@
+package be.buithg.supergoal.presentation.ui.challenges
+
+import androidx.annotation.StringRes
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import be.buithg.supergoal.R
+import be.buithg.supergoal.domain.model.Goal
+import be.buithg.supergoal.domain.model.GoalCategory
+import be.buithg.supergoal.domain.model.SubGoal
+import be.buithg.supergoal.domain.usecase.GoalUseCases
+import dagger.hilt.android.lifecycle.HiltViewModel
+import java.text.SimpleDateFormat
+import java.util.Calendar
+import java.util.Locale
+import javax.inject.Inject
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+@HiltViewModel
+class ChallengeDetailViewModel @Inject constructor(
+    private val goalUseCases: GoalUseCases,
+    savedStateHandle: SavedStateHandle,
+) : ViewModel() {
+
+    private val dateFormatter = SimpleDateFormat("MMM dd, yyyy", Locale.getDefault())
+
+    private val _uiState = MutableStateFlow(ChallengeDetailUiState())
+    val uiState: StateFlow<ChallengeDetailUiState> = _uiState.asStateFlow()
+
+    private val eventsChannel = Channel<ChallengeDetailEvent>(Channel.BUFFERED)
+    val events = eventsChannel.receiveAsFlow()
+
+    private var selectedChallenge: Challenge? = null
+    private var computedDeadlineMillis: Long? = null
+
+    init {
+        val challengeId = savedStateHandle.get<Int>("challengeId") ?: -1
+        if (challengeId == -1) {
+            sendMessage(R.string.challenge_detail_missing)
+            sendEvent(ChallengeDetailEvent.CloseScreen)
+        } else {
+            loadChallenge(challengeId)
+        }
+    }
+
+    fun onSubGoalChecked(id: Long, isChecked: Boolean) {
+        _uiState.update { state ->
+            state.copy(
+                subGoals = state.subGoals.map { subGoal ->
+                    if (subGoal.id == id) subGoal.copy(isChecked = isChecked) else subGoal
+                },
+            )
+        }
+    }
+
+    fun onStartChallenge() {
+        val challenge = selectedChallenge
+        val deadlineMillis = computedDeadlineMillis
+        if (challenge == null || deadlineMillis == null) {
+            sendMessage(R.string.challenge_detail_missing)
+            sendEvent(ChallengeDetailEvent.CloseScreen)
+            return
+        }
+
+        val goal = Goal(
+            title = challenge.title,
+            category = GoalCategory.fromRaw(challenge.category),
+            deadlineMillis = deadlineMillis,
+            imageUri = null,
+            createdAtMillis = System.currentTimeMillis(),
+            subGoals = challenge.subgoals.map { title -> SubGoal(title = title) },
+        )
+
+        viewModelScope.launch {
+            goalUseCases.upsertGoal(goal)
+            sendMessage(R.string.challenge_detail_toast)
+            sendEvent(ChallengeDetailEvent.CloseScreen)
+        }
+    }
+
+    private fun loadChallenge(challengeId: Int) {
+        val challenge = ChallengeDataSource.getChallenges().firstOrNull { it.id == challengeId }
+        if (challenge == null) {
+            sendMessage(R.string.challenge_detail_missing)
+            sendEvent(ChallengeDetailEvent.CloseScreen)
+            return
+        }
+
+        selectedChallenge = challenge
+        val deadlineMillis = calculateDeadlineMillis(challenge.durationDays)
+        computedDeadlineMillis = deadlineMillis
+        val formattedDeadline = synchronized(dateFormatter) {
+            dateFormatter.format(Calendar.getInstance().apply {
+                timeInMillis = deadlineMillis
+            }.time)
+        }
+
+        _uiState.value = ChallengeDetailUiState(
+            isLoading = false,
+            title = challenge.title,
+            category = challenge.category,
+            subGoals = challenge.subgoals.mapIndexed { index, title ->
+                ChallengeSubGoalUi(id = index.toLong(), title = title)
+            },
+            deadlineText = formattedDeadline,
+            durationDays = challenge.durationDays,
+            illustrationRes = challenge.imageRes,
+        )
+    }
+
+    private fun calculateDeadlineMillis(durationDays: Int): Long {
+        val calendar = Calendar.getInstance().apply {
+            set(Calendar.HOUR_OF_DAY, 23)
+            set(Calendar.MINUTE, 59)
+            set(Calendar.SECOND, 59)
+            set(Calendar.MILLISECOND, 999)
+            add(Calendar.DAY_OF_YEAR, durationDays)
+        }
+        return calendar.timeInMillis
+    }
+
+    private fun sendMessage(@StringRes messageRes: Int) {
+        eventsChannel.trySend(ChallengeDetailEvent.ShowMessage(messageRes))
+    }
+
+    private fun sendEvent(event: ChallengeDetailEvent) {
+        eventsChannel.trySend(event)
+    }
+}
+
+sealed interface ChallengeDetailEvent {
+    data class ShowMessage(@StringRes val messageRes: Int) : ChallengeDetailEvent
+    object CloseScreen : ChallengeDetailEvent
+}

--- a/app/src/main/java/be/buithg/supergoal/presentation/ui/challenges/ChallengeFragment.kt
+++ b/app/src/main/java/be/buithg/supergoal/presentation/ui/challenges/ChallengeFragment.kt
@@ -1,60 +1,54 @@
 package be.buithg.supergoal.presentation.ui.challenges
 
 import android.os.Bundle
-import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.os.bundleOf
+import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.findNavController
+import androidx.recyclerview.widget.LinearLayoutManager
 import be.buithg.supergoal.R
+import be.buithg.supergoal.databinding.FragmentChallengeBinding
 
-// TODO: Rename parameter arguments, choose names that match
-// the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
-private const val ARG_PARAM1 = "param1"
-private const val ARG_PARAM2 = "param2"
-
-/**
- * A simple [Fragment] subclass.
- * Use the [ChallengeFragment.newInstance] factory method to
- * create an instance of this fragment.
- */
 class ChallengeFragment : Fragment() {
-    // TODO: Rename and change types of parameters
-    private var param1: String? = null
-    private var param2: String? = null
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        arguments?.let {
-            param1 = it.getString(ARG_PARAM1)
-            param2 = it.getString(ARG_PARAM2)
+    private var _binding: FragmentChallengeBinding? = null
+    private val binding get() = _binding!!
+
+    private lateinit var challengeAdapter: ChallengeAdapter
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        _binding = FragmentChallengeBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setupRecyclerView()
+        challengeAdapter.submitList(ChallengeDataSource.getChallenges())
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        binding.rvChallenges.adapter = null
+        _binding = null
+    }
+
+    private fun setupRecyclerView() {
+        challengeAdapter = ChallengeAdapter(onChallengeClick = ::openChallengeDetails)
+        binding.rvChallenges.apply {
+            layoutManager = LinearLayoutManager(requireContext())
+            adapter = challengeAdapter
         }
     }
 
-    override fun onCreateView(
-        inflater: LayoutInflater, container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View? {
-        // Inflate the layout for this fragment
-        return inflater.inflate(R.layout.fragment_challenge, container, false)
-    }
-
-    companion object {
-        /**
-         * Use this factory method to create a new instance of
-         * this fragment using the provided parameters.
-         *
-         * @param param1 Parameter 1.
-         * @param param2 Parameter 2.
-         * @return A new instance of fragment ChallengeFragment.
-         */
-        // TODO: Rename and change types and number of parameters
-        @JvmStatic
-        fun newInstance(param1: String, param2: String) =
-            ChallengeFragment().apply {
-                arguments = Bundle().apply {
-                    putString(ARG_PARAM1, param1)
-                    putString(ARG_PARAM2, param2)
-                }
-            }
+    private fun openChallengeDetails(challenge: Challenge) {
+        val arguments = bundleOf("challengeId" to challenge.id)
+        findNavController().navigate(R.id.challengeDetailFragment, arguments)
     }
 }

--- a/app/src/main/java/be/buithg/supergoal/presentation/ui/challenges/ChallengeSubGoalAdapter.kt
+++ b/app/src/main/java/be/buithg/supergoal/presentation/ui/challenges/ChallengeSubGoalAdapter.kt
@@ -1,0 +1,50 @@
+package be.buithg.supergoal.presentation.ui.challenges
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import be.buithg.supergoal.databinding.ItemChallengeSubgoalBinding
+
+class ChallengeSubGoalAdapter(
+    private val onCheckedChange: (Long, Boolean) -> Unit,
+) : ListAdapter<ChallengeSubGoalUi, ChallengeSubGoalAdapter.SubGoalViewHolder>(DiffCallback) {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): SubGoalViewHolder {
+        val inflater = LayoutInflater.from(parent.context)
+        val binding = ItemChallengeSubgoalBinding.inflate(inflater, parent, false)
+        return SubGoalViewHolder(binding, onCheckedChange)
+    }
+
+    override fun onBindViewHolder(holder: SubGoalViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+
+    class SubGoalViewHolder(
+        private val binding: ItemChallengeSubgoalBinding,
+        private val onCheckedChange: (Long, Boolean) -> Unit,
+    ) : RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(item: ChallengeSubGoalUi) = with(binding) {
+            checkSubGoal.setOnCheckedChangeListener(null)
+            checkSubGoal.text = item.title
+            checkSubGoal.isChecked = item.isChecked
+            checkSubGoal.setOnCheckedChangeListener { _, isChecked ->
+                onCheckedChange(item.id, isChecked)
+            }
+        }
+    }
+
+    private object DiffCallback : DiffUtil.ItemCallback<ChallengeSubGoalUi>() {
+        override fun areItemsTheSame(
+            oldItem: ChallengeSubGoalUi,
+            newItem: ChallengeSubGoalUi,
+        ): Boolean = oldItem.id == newItem.id
+
+        override fun areContentsTheSame(
+            oldItem: ChallengeSubGoalUi,
+            newItem: ChallengeSubGoalUi,
+        ): Boolean = oldItem == newItem
+    }
+}

--- a/app/src/main/res/color/selector_checkbox_tint.xml
+++ b/app/src/main/res/color/selector_checkbox_tint.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:alpha="1" android:color="#EE322E" android:state_checked="true" />
+    <item android:alpha="0.6" android:color="#FFFFFFFF" android:state_checked="false" />
+</selector>

--- a/app/src/main/res/drawable/bg_article_card.xml
+++ b/app/src/main/res/drawable/bg_article_card.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners android:radius="24dp" />
+    <gradient
+        android:angle="90"
+        android:endColor="#33151C2E"
+        android:startColor="#66151C2E" />
+</shape>

--- a/app/src/main/res/layout/article_item.xml
+++ b/app/src/main/res/layout/article_item.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginBottom="24dp"
+    android:backgroundTint="@android:color/transparent"
+    android:clipToPadding="false"
+    android:elevation="0dp"
+    app:cardBackgroundColor="@android:color/transparent"
+    app:cardCornerRadius="24dp"
+    app:strokeColor="#33FFFFFF"
+    app:strokeWidth="1dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@drawable/bg_article_card"
+        android:orientation="vertical"
+        android:padding="20dp">
+
+        <com.google.android.material.imageview.ShapeableImageView
+            android:id="@+id/ivCover"
+            android:layout_width="match_parent"
+            android:layout_height="180dp"
+            android:contentDescription="@string/article_cover_content_description"
+            android:scaleType="centerCrop"
+            android:src="@drawable/article_im"
+            app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.App.Article"
+            app:strokeColor="#F23230"
+            app:strokeWidth="2dp" />
+
+        <TextView
+            android:id="@+id/tvTitle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:fontFamily="@font/poppins_extra_bold"
+            android:textColor="@android:color/white"
+            android:textSize="20sp"
+            tools:text="Orion Varela: The Quiet Rise" />
+
+        <TextView
+            android:id="@+id/tvContent"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:fontFamily="@font/poppins_regular"
+            android:lineSpacingExtra="4dp"
+            android:textColor="#CCFFFFFF"
+            android:textSize="14sp"
+            tools:text="I grew up in a coastal town where the wind never rested..." />
+
+    </LinearLayout>
+
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/layout/challenge_item.xml
+++ b/app/src/main/res/layout/challenge_item.xml
@@ -7,17 +7,17 @@
     android:background="@drawable/bg_goal_item"
     android:paddingEnd="16dp">
 
-    <!-- Обложка цели (квадрат с закруглениями) -->
     <com.google.android.material.imageview.ShapeableImageView
         android:id="@+id/ivCover"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:contentDescription="@string/app_name"
-        android:paddingVertical="10dp"
         android:paddingStart="10dp"
+        android:paddingTop="10dp"
         android:paddingEnd="5dp"
+        android:paddingBottom="10dp"
         android:scaleType="centerCrop"
-        android:src="@drawable/ic_launcher_background"
+        android:src="@drawable/ball_ic"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintDimensionRatio="1:1"
         app:layout_constraintStart_toStartOf="parent"
@@ -26,7 +26,16 @@
         app:strokeColor="#F23230"
         app:strokeWidth="2dp" />
 
-    <!-- Заголовок цели -->
+    <ImageView
+        android:id="@+id/ivChevron"
+        android:layout_width="20dp"
+        android:layout_height="20dp"
+        android:layout_marginTop="20dp"
+        android:layout_marginEnd="5dp"
+        android:src="@drawable/play_ic"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
     <TextView
         android:id="@+id/tvTitle"
         android:layout_width="0dp"
@@ -41,78 +50,59 @@
         android:textColor="@android:color/white"
         android:textSize="16sp"
         android:textStyle="bold"
-        app:layout_constraintEnd_toStartOf="@+id/imageView"
+        app:layout_constraintEnd_toStartOf="@id/ivChevron"
         app:layout_constraintStart_toEndOf="@id/ivCover"
         app:layout_constraintTop_toTopOf="@id/ivCover"
         tools:text="Win Championship Trophy" />
 
-    <!-- Процент справа (красный) -->
-
-    <!-- Категория/подзаголовок -->
-
-
-    <!-- Прогресс-бар -->
-
-    <!-- Дата дедлайна -->
     <TextView
-        android:id="@+id/tvDeadline"
+        android:id="@+id/tvCategory"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="12dp"
-        android:elevation="1dp"
-        android:ellipsize="end"
+        android:layout_marginTop="8dp"
         android:fontFamily="@font/poppins_regular"
-        android:gravity="start|center_vertical"
-        android:inputType="textMultiLine"
-        android:scrollHorizontally="false"
-        android:singleLine="false"
-        android:text="Body"
         android:textColor="#8FFFFFFF"
-        android:textSize="16sp"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@+id/ivCover"
-        app:layout_constraintTop_toBottomOf="@+id/tvTitle" />
+        android:textSize="14sp"
+        app:layout_constraintEnd_toStartOf="@id/ivChevron"
+        app:layout_constraintStart_toEndOf="@id/ivCover"
+        app:layout_constraintTop_toBottomOf="@id/tvTitle"
+        tools:text="Category: Body" />
 
     <TextView
-        android:id="@+id/tvTime"
+        android:id="@+id/tvCompletionTime"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:elevation="1dp"
         android:layout_marginStart="12dp"
-        android:ellipsize="end"
+        android:layout_marginTop="4dp"
+        android:layout_marginEnd="12dp"
+        android:layout_marginBottom="16dp"
         android:fontFamily="@font/poppins_regular"
-        android:gravity="start|center_vertical"
-        android:inputType="textMultiLine"
-        android:scrollHorizontally="false"
-        android:singleLine="false"
-        android:text="Body"
-        android:layout_marginBottom="15dp"
         android:textColor="#8FFFFFFF"
-        android:textSize="16sp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@+id/materialButton"
-        app:layout_constraintStart_toEndOf="@+id/ivCover"
-        tools:text="7 days" />
-
-    <ImageView
-        android:id="@+id/imageView"
-        android:layout_width="20dp"
-        android:layout_height="20dp"
-        android:layout_marginTop="20dp"
-        android:layout_marginEnd="5dp"
-        android:src="@drawable/play_ic"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        android:textSize="14sp"
+        app:layout_constraintBottom_toBottomOf="@id/ivCover"
+        app:layout_constraintEnd_toStartOf="@id/btnAddGoal"
+        app:layout_constraintStart_toEndOf="@id/ivCover"
+        app:layout_constraintTop_toBottomOf="@id/tvCategory"
+        tools:text="7-day challenge" />
 
     <com.google.android.material.button.MaterialButton
-        android:id="@+id/materialButton"
+        android:id="@+id/btnAddGoal"
+        style="@style/Widget.MaterialComponents.Button.TextButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginBottom="10dp"
         android:backgroundTint="#F23230"
         android:fontFamily="@font/poppins_bold"
-        android:paddingVertical="5dp"
-        android:text="Add Goal"
+        android:minHeight="0dp"
+        android:paddingHorizontal="16dp"
+        android:paddingVertical="6dp"
+        android:text="@string/challenge_add_goal"
+        android:textAllCaps="false"
+        android:textColor="@android:color/white"
+        android:textSize="14sp"
+        app:cornerRadius="16dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_article.xml
+++ b/app/src/main/res/layout/fragment_article.xml
@@ -1,74 +1,41 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@drawable/add_goal_bg"
-    android:paddingTop="20dp"
+    android:paddingVertical="32dp"
     tools:context=".presentation.ui.article.ArticleFragment">
 
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_marginHorizontal="20dp"
-        android:orientation="vertical">
+    <TextView
+        android:id="@+id/tvHeading"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="24dp"
+        android:layout_marginEnd="24dp"
+        android:fontFamily="@font/poppins_extra_bold"
+        android:text="@string/article_heading"
+        android:textAllCaps="true"
+        android:textColor="@android:color/white"
+        android:textSize="36sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
-        <TextView
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_marginTop="10dp"
-            android:layout_weight="700"
-            android:drawableStart="@drawable/back_ic"
-            android:drawablePadding="10dp"
-            android:fontFamily="@font/poppins_bold"
-            android:text="Back"
-            android:textColor="@color/white"
-            android:textSize="16sp" />
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/rvArticles"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginStart="24dp"
+        android:layout_marginTop="24dp"
+        android:layout_marginEnd="24dp"
+        android:clipToPadding="false"
+        android:paddingBottom="32dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tvHeading"
+        tools:listitem="@layout/article_item" />
 
-        <TextView
-            android:id="@+id/tvMyGoals"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:fontFamily="@font/poppins_extra_bold"
-            android:text="Article"
-            android:textColor="@android:color/white"
-            android:textSize="40sp" />
-
-
-        <com.google.android.material.imageview.ShapeableImageView
-            android:layout_width="match_parent"
-            android:layout_height="160dp"
-            android:scaleType="centerCrop"
-            android:src="@drawable/article_im"
-            app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.App.Article"
-            app:strokeColor="#F23230"
-            app:strokeWidth="2dp" />
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_marginTop="15dp"
-            android:layout_marginBottom="15dp"
-            android:background="@drawable/bg_input_goal"
-            android:orientation="vertical"
-            android:padding="20dp">
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:fontFamily="@font/poppins_extra_bold"
-                android:text="Orion Varela: The Quiet Rise"
-                android:textColor="@color/white"
-                android:textSize="20sp" />
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:textColor="#D8FFFFFF"
-                android:fontFamily="@font/poppins_regular"
-                android:text="I grew up in a coastal town where the wind never rested. The ball skipped across concrete and sand, and every bounce tried to trick me. I used to believe talent was something you found, like a coin on the beach. It took me years to learn that talent is mostly repetition that refuses to be boring. On training days I arrived early and I left late. "/>
-        </LinearLayout>
-    </LinearLayout>
-
-</androidx.core.widget.NestedScrollView>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_challenge.xml
+++ b/app/src/main/res/layout/fragment_challenge.xml
@@ -1,86 +1,41 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@drawable/add_goal_bg"
+    android:paddingVertical="32dp"
     tools:context=".presentation.ui.challenges.ChallengeFragment">
 
+    <TextView
+        android:id="@+id/tvHeading"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="24dp"
+        android:layout_marginEnd="24dp"
+        android:fontFamily="@font/poppins_extra_bold"
+        android:text="@string/challenge_heading"
+        android:textAllCaps="true"
+        android:textColor="@android:color/white"
+        android:textSize="36sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:paddingTop="20dp"
-        android:orientation="vertical"
-        android:layout_height="match_parent">
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/rvChallenges"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginStart="24dp"
+        android:layout_marginTop="24dp"
+        android:layout_marginEnd="24dp"
+        android:clipToPadding="false"
+        android:paddingBottom="32dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tvHeading"
+        tools:listitem="@layout/challenge_item" />
 
-
-
-
-        <TextView
-            android:id="@+id/tvMyGoals"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="20dp"
-            android:layout_marginTop="10dp"
-            android:fontFamily="@font/poppins_extra_bold"
-            android:textAllCaps="true"
-            android:text="Challenge"
-            android:textColor="@android:color/white"
-            android:textSize="40sp" />
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:gravity="center"
-            android:orientation="horizontal"
-            android:paddingVertical="16dp">
-
-            <!-- All -->
-            <TextView
-                android:id="@+id/btn_all"
-                android:layout_width="110dp"
-                android:layout_height="40dp"
-                android:layout_marginEnd="12dp"
-                android:gravity="center"
-                android:background="@drawable/bg_tab_selected"
-                android:text="All"
-                android:textColor="@android:color/white"
-                android:textStyle="bold"
-                android:textSize="16sp" />
-
-            <!-- Active -->
-            <TextView
-                android:id="@+id/btn_active"
-                android:layout_width="110dp"
-                android:layout_height="40dp"
-                android:layout_marginEnd="12dp"
-                android:gravity="center"
-                android:background="@drawable/bg_tab_unselected"
-                android:text="Active"
-                android:textColor="@android:color/white"
-                android:textStyle="bold"
-                android:textSize="16sp" />
-
-            <!-- Archived -->
-            <TextView
-                android:id="@+id/btn_archived"
-                android:layout_width="110dp"
-                android:layout_height="40dp"
-                android:gravity="center"
-                android:background="@drawable/bg_tab_unselected"
-                android:text="Archived"
-                android:textColor="@android:color/white"
-                android:textStyle="bold"
-                android:textSize="16sp" />
-
-        </LinearLayout>
-
-        <androidx.recyclerview.widget.RecyclerView
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_marginHorizontal="20dp"/>
-    </LinearLayout>
-
-</ScrollView>
-
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_challenge_detail.xml
+++ b/app/src/main/res/layout/fragment_challenge_detail.xml
@@ -1,167 +1,205 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="#17181F"
-
     tools:context=".presentation.ui.challenges.ChallengeDetailFragment">
 
     <ImageView
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:id="@+id/imageBackground"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:contentDescription="@null"
         android:scaleType="centerCrop"
-        android:src="@drawable/challenge_bg" />
+        android:src="@drawable/challenge_detail_screen_bg"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
-    <ScrollView
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
+    <View
+        android:id="@+id/backgroundScrim"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#CC17181F"
+        app:layout_constraintBottom_toBottomOf="@id/imageBackground"
+        app:layout_constraintEnd_toEndOf="@id/imageBackground"
+        app:layout_constraintStart_toStartOf="@id/imageBackground"
+        app:layout_constraintTop_toTopOf="@id/imageBackground" />
 
-        android:paddingTop="20dp">
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/buttonBack"
+        style="@style/Widget.MaterialComponents.Button.TextButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="24dp"
+        android:layout_marginTop="32dp"
+        android:backgroundTint="@android:color/transparent"
+        android:icon="@drawable/back_ic"
+        android:iconGravity="textStart"
+        android:iconPadding="8dp"
+        android:minHeight="0dp"
+        android:paddingHorizontal="8dp"
+        android:paddingVertical="4dp"
+        android:text="@string/challenge_detail_back"
+        android:textAllCaps="false"
+        android:textColor="@android:color/white"
+        android:textSize="16sp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <androidx.core.widget.NestedScrollView
+        android:id="@+id/contentScroll"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:clipToPadding="false"
+        android:paddingBottom="96dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/buttonBack">
 
         <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_marginStart="20dp"
-            android:layout_marginTop="20dp"
-            android:layout_marginEnd="20dp"
-            android:orientation="vertical">
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:paddingStart="24dp"
+            android:paddingEnd="24dp"
+            android:paddingTop="24dp">
 
-            <TextView
+            <ImageView
+                android:id="@+id/imageIllustration"
                 android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:layout_weight="700"
-                android:drawableStart="@drawable/back_ic"
-                android:drawablePadding="10dp"
-                android:fontFamily="@font/poppins_bold"
-                android:text="Back"
-                android:textColor="@color/white"
-                android:textSize="16sp" />
+                android:layout_height="220dp"
+                android:contentDescription="@string/challenge_detail_illustration_content_description"
+                android:scaleType="fitCenter"
+                android:src="@drawable/challenge_screen_ic" />
 
             <TextView
-                android:id="@+id/tvMyGoals"
+                android:id="@+id/textTitle"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="10dp"
+                android:layout_marginTop="24dp"
                 android:fontFamily="@font/poppins_extra_bold"
-                android:text="Sunrise Scan"
                 android:textColor="@android:color/white"
-                android:textSize="40sp" />
+                android:textSize="36sp"
+                android:textStyle="bold"
+                tools:text="Sunrise Scan" />
 
-            <FrameLayout
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/cardContent"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:background="@drawable/bg_input_goal"
-               >
-
-                <com.google.android.material.button.MaterialButton
-                    android:layout_width="100dp"
-                    android:layout_height="45dp"
-                    android:layout_gravity="end"
-                    android:text="Activ"
-                    android:backgroundTint="#00FFFFFF"
-                    android:layout_marginEnd="15dp"
-                    android:layout_marginTop="20dp"
-                    app:strokeColor="#00A637"
-                    app:strokeWidth="1dp" />
-
-                <ImageView
-                    android:layout_width="50dp"
-                    android:layout_gravity="end"
-                    android:visibility="gone"
-                    android:layout_marginEnd="15dp"
-                    android:layout_marginTop="20dp"
-                    android:layout_height="50dp"
-                    android:src="@drawable/completed_ic"/>
-
-
+                android:layout_marginTop="24dp"
+                app:cardBackgroundColor="#252A34"
+                app:cardCornerRadius="22dp"
+                app:cardUseCompatPadding="true">
 
                 <LinearLayout
                     android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:paddingVertical="25dp"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
                     android:paddingHorizontal="20dp"
-                    android:orientation="vertical">
+                    android:paddingVertical="24dp">
 
-
-                    <LinearLayout
+                    <TextView
+                        android:id="@+id/textCategoryLabel"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:layout_marginTop="20dp"
+                        android:text="@string/challenge_detail_category_label"
+                        android:textAllCaps="true"
+                        android:textColor="#99FFFFFF"
+                        android:textSize="14sp" />
 
-                        android:orientation="horizontal">
+                    <TextView
+                        android:id="@+id/textCategoryValue"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="8dp"
+                        android:fontFamily="@font/poppins_bold"
+                        android:textColor="@android:color/white"
+                        android:textSize="18sp"
+                        tools:text="Body" />
 
-                        <TextView
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:fontFamily="@font/poppins_regular"
-                            android:text="Category:"
-                            android:textAllCaps="true"
-                            android:textColor="#98FFFFFF"
-                            android:textSize="14sp" />
-
-                        <TextView
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_marginStart="10dp"
-                            android:fontFamily="@font/poppins_bold"
-                            android:text="Body"
-                            android:textAllCaps="false"
-                            android:textColor="@color/white"
-                            android:textSize="18sp" />
-
-
-                    </LinearLayout>
-
+                    <TextView
+                        android:id="@+id/textSubGoalsHeader"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="24dp"
+                        android:fontFamily="@font/poppins_bold"
+                        android:text="@string/challenge_detail_subgoals"
+                        android:textAllCaps="true"
+                        android:textColor="#99FFFFFF"
+                        android:textSize="14sp" />
 
                     <androidx.recyclerview.widget.RecyclerView
-                        android:layout_width="match_parent"
-                        android:layout_height="match_parent"
-                        android:layout_marginTop="15dp" />
-
-                    <LinearLayout
+                        android:id="@+id/listSubGoals"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:orientation="horizontal">
+                        android:layout_marginTop="12dp"
+                        android:nestedScrollingEnabled="false"
+                        tools:listitem="@layout/item_challenge_subgoal" />
 
-                        <TextView
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_marginTop="20dp"
-                            android:fontFamily="@font/poppins_medium"
-                            android:text="Deadline:"
-                            android:textColor="@color/white"
-                            android:textSize="18sp" />
+                    <TextView
+                        android:id="@+id/textEmptySubGoals"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="12dp"
+                        android:fontFamily="@font/poppins_regular"
+                        android:gravity="center"
+                        android:text="@string/challenge_detail_empty_subgoals"
+                        android:textColor="#80FFFFFF"
+                        android:textSize="14sp"
+                        android:visibility="gone" />
 
-                        <TextView
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_marginStart="5dp"
-                            android:layout_marginTop="20dp"
-                            android:fontFamily="@font/poppins_regular"
-                            android:text="7 days from today's date"
-                            android:textColor="@color/white"
-                            android:textSize="18sp" />
-                    </LinearLayout>
+                    <View
+                        android:layout_width="match_parent"
+                        android:layout_height="1dp"
+                        android:layout_marginTop="24dp"
+                        android:background="#1AFFFFFF" />
+
+                    <TextView
+                        android:id="@+id/textDeadlineLabel"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="24dp"
+                        android:text="@string/challenge_detail_deadline_label"
+                        android:textAllCaps="true"
+                        android:textColor="#99FFFFFF"
+                        android:textSize="14sp" />
+
+                    <TextView
+                        android:id="@+id/textDeadlineValue"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="8dp"
+                        android:fontFamily="@font/poppins_medium"
+                        android:textColor="@android:color/white"
+                        android:textSize="16sp"
+                        tools:text="Mar 15, 2025 (7 days from today)" />
                 </LinearLayout>
-            </FrameLayout>
-
+            </com.google.android.material.card.MaterialCardView>
 
             <com.google.android.material.button.MaterialButton
+                android:id="@+id/buttonStartChallenge"
                 android:layout_width="match_parent"
-                android:layout_height="55dp"
-                android:layout_marginHorizontal="40dp"
-                android:layout_marginTop="30dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="32dp"
+                android:layout_marginBottom="40dp"
                 android:fontFamily="@font/poppins_bold"
-                android:text="Start Challenge"
+                android:minHeight="0dp"
+                android:paddingVertical="14dp"
+                android:text="@string/challenge_detail_start"
                 android:textAllCaps="true"
                 android:textSize="16sp"
-                app:backgroundTint="#EE322E" />
-
+                app:cornerRadius="18dp"
+                app:iconGravity="textStart"
+                app:backgroundTint="#EE322E"
+                app:strokeColor="#4DFFFFFF"
+                app:strokeWidth="1dp" />
         </LinearLayout>
+    </androidx.core.widget.NestedScrollView>
 
-    </ScrollView>
-
-
-</FrameLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_challenge_subgoal.xml
+++ b/app/src/main/res/layout/item_challenge_subgoal.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:gravity="center_vertical"
+    android:minHeight="48dp"
+    android:orientation="horizontal">
+
+    <com.google.android.material.checkbox.MaterialCheckBox
+        android:id="@+id/checkSubGoal"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:paddingVertical="8dp"
+        android:textColor="@android:color/white"
+        android:textSize="16sp"
+        app:useMaterialThemeColors="false"
+        android:buttonTint="@color/selector_checkbox_tint" />
+
+</LinearLayout>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -88,5 +88,10 @@
         android:id="@+id/challengeDetailFragment"
         android:name="be.buithg.supergoal.presentation.ui.challenges.ChallengeDetailFragment"
         android:label="fragment_challenge_detail"
-        tools:layout="@layout/fragment_challenge_detail" />
+        tools:layout="@layout/fragment_challenge_detail">
+        <argument
+            android:name="challengeId"
+            app:argType="integer"
+            android:defaultValue="-1" />
+    </fragment>
 </navigation>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -45,4 +45,32 @@
     <string name="analytics_category_distribution_title">Time distribution by category</string>
     <string name="analytics_empty_state">No data for analytics graph</string>
     <string name="analytics_percent_value">%1$d%%</string>
+
+    <!-- Challenges -->
+    <string name="challenge_heading">Motivation</string>
+    <string name="challenge_add_goal">Add Goal</string>
+    <string name="challenge_category_format">Category: %1$s</string>
+    <plurals name="challenge_completion_time">
+        <item quantity="one">%1$d-day challenge</item>
+        <item quantity="other">%1$d-day challenge</item>
+    </plurals>
+    <string name="challenge_detail_back">Back</string>
+    <string name="challenge_detail_illustration_content_description">Football challenge illustration</string>
+    <string name="challenge_detail_category_label">Category</string>
+    <string name="challenge_detail_subgoals">Sub-goals</string>
+    <string name="challenge_detail_empty_subgoals">No sub-goals available.</string>
+    <string name="challenge_detail_deadline_label">Deadline</string>
+    <string name="challenge_detail_deadline_value">%1$s (%2$s)</string>
+    <string name="challenge_detail_deadline_placeholder">—</string>
+    <plurals name="challenge_detail_deadline_suffix">
+        <item quantity="one">%d day from today</item>
+        <item quantity="other">%d days from today</item>
+    </plurals>
+    <string name="challenge_detail_start">Start Challenge</string>
+    <string name="challenge_detail_toast">Challenge goal is successfully added</string>
+    <string name="challenge_detail_missing">Challenge not found</string>
+
+    <!-- Articles -->
+    <string name="article_heading">Motivation Stories</string>
+    <string name="article_cover_content_description">Article cover image</string>
 </resources>


### PR DESCRIPTION
## Summary
- replace the placeholder ChallengeDetailFragment with a Hilt-backed screen that loads challenge data, renders the illustration, and formats deadline messaging
- add a dedicated view model, UI state, and checkbox list adapter so sub-goals can be toggled and the start action persists a full Goal via the repository
- refresh the detail layout, challenge assets, and strings to match the football-inspired design while computing challenge deadlines from today

## Testing
- ./gradlew lint *(fails: Android SDK is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5b98282a4832aa98ddca49521227a