### PR TITLE
Add challenge completion lifecycle controls

### DIFF
--- a/app/src/main/java/be/buithg/supergoal/presentation/ui/challenges/ChallengeAdapter.kt
+++ b/app/src/main/java/be/buithg/supergoal/presentation/ui/challenges/ChallengeAdapter.kt
@@ -7,19 +7,32 @@ import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import be.buithg.supergoal.R
 import be.buithg.supergoal.databinding.ChallengeItemBinding
+import be.buithg.supergoal.databinding.ChallengeItemCompletedBinding
 
 class ChallengeAdapter(
     private val onChallengeClick: (Challenge) -> Unit,
-) : ListAdapter<Challenge, ChallengeAdapter.ChallengeViewHolder>(DiffCallback) {
+) : ListAdapter<ChallengeListItem, RecyclerView.ViewHolder>(DiffCallback) {
 
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ChallengeViewHolder {
+    override fun getItemViewType(position: Int): Int =
+        if (getItem(position).isCompleted) VIEW_TYPE_COMPLETED else VIEW_TYPE_DEFAULT
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
         val inflater = LayoutInflater.from(parent.context)
-        val binding = ChallengeItemBinding.inflate(inflater, parent, false)
-        return ChallengeViewHolder(binding, onChallengeClick)
+        return if (viewType == VIEW_TYPE_COMPLETED) {
+            val binding = ChallengeItemCompletedBinding.inflate(inflater, parent, false)
+            CompletedViewHolder(binding, onChallengeClick)
+        } else {
+            val binding = ChallengeItemBinding.inflate(inflater, parent, false)
+            ChallengeViewHolder(binding, onChallengeClick)
+        }
     }
 
-    override fun onBindViewHolder(holder: ChallengeViewHolder, position: Int) {
-        holder.bind(getItem(position))
+    override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
+        val item = getItem(position)
+        when (holder) {
+            is ChallengeViewHolder -> holder.bind(item.challenge)
+            is CompletedViewHolder -> holder.bind(item.challenge)
+        }
     }
 
     class ChallengeViewHolder(
@@ -42,11 +55,30 @@ class ChallengeAdapter(
         }
     }
 
-    private object DiffCallback : DiffUtil.ItemCallback<Challenge>() {
-        override fun areItemsTheSame(oldItem: Challenge, newItem: Challenge): Boolean =
-            oldItem.id == newItem.id
+    class CompletedViewHolder(
+        private val binding: ChallengeItemCompletedBinding,
+        private val onChallengeClick: (Challenge) -> Unit,
+    ) : RecyclerView.ViewHolder(binding.root) {
 
-        override fun areContentsTheSame(oldItem: Challenge, newItem: Challenge): Boolean =
+        fun bind(item: Challenge) = with(binding) {
+            ivCover.setImageResource(item.imageRes)
+            tvTitle.text = item.title
+            tvDeadline.text = root.context.getString(R.string.challenge_category_format, item.category)
+            tvStatus.text = root.context.getString(R.string.challenge_completed_status)
+            root.setOnClickListener { onChallengeClick(item) }
+        }
+    }
+
+    private object DiffCallback : DiffUtil.ItemCallback<ChallengeListItem>() {
+        override fun areItemsTheSame(oldItem: ChallengeListItem, newItem: ChallengeListItem): Boolean =
+            oldItem.challenge.id == newItem.challenge.id
+
+        override fun areContentsTheSame(oldItem: ChallengeListItem, newItem: ChallengeListItem): Boolean =
             oldItem == newItem
+    }
+
+    private companion object {
+        const val VIEW_TYPE_DEFAULT = 0
+        const val VIEW_TYPE_COMPLETED = 1
     }
 }

--- a/app/src/main/java/be/buithg/supergoal/presentation/ui/challenges/ChallengeDetailFragment.kt
+++ b/app/src/main/java/be/buithg/supergoal/presentation/ui/challenges/ChallengeDetailFragment.kt
@@ -64,6 +64,8 @@ class ChallengeDetailFragment : Fragment() {
     private fun setupListeners() = with(binding) {
         buttonBack.setOnClickListener { popIfPossible() }
         buttonStartChallenge.setOnClickListener { viewModel.onStartChallenge() }
+        buttonCompleteChallenge.setOnClickListener { viewModel.onCompleteChallenge() }
+        buttonPerformAgain.setOnClickListener { viewModel.onPerformAgain() }
     }
 
     private fun collectState() {
@@ -121,8 +123,23 @@ class ChallengeDetailFragment : Fragment() {
         }
 
         cardContent.isVisible = state.hasContent
-        buttonStartChallenge.isEnabled = state.hasContent
-        buttonStartChallenge.alpha = if (state.hasContent) 1f else 0.5f
+        val isChallengeStarted = state.isChallengeStarted
+        val isChallengeCompleted = state.isChallengeCompleted
+
+        buttonStartChallenge.isVisible = state.hasContent && !isChallengeStarted
+        buttonStartChallenge.isEnabled = state.hasContent && !isChallengeStarted
+        buttonStartChallenge.alpha = if (state.hasContent && !isChallengeStarted) 1f else 0.5f
+
+        buttonActiv.isVisible = isChallengeStarted
+
+        val showCompleteButton = state.challengeStatus == ChallengeStatus.Active
+        buttonCompleteChallenge.isVisible = showCompleteButton
+        buttonCompleteChallenge.isEnabled = showCompleteButton
+        buttonCompleteChallenge.alpha = if (state.canCompleteChallenge) 1f else 0.7f
+
+        statusCompleted.isVisible = isChallengeCompleted
+        buttonPerformAgain.isVisible = isChallengeCompleted
+        buttonPerformAgain.isEnabled = isChallengeCompleted
     }
 
     private fun popIfPossible() {

--- a/app/src/main/java/be/buithg/supergoal/presentation/ui/challenges/ChallengeDetailUiState.kt
+++ b/app/src/main/java/be/buithg/supergoal/presentation/ui/challenges/ChallengeDetailUiState.kt
@@ -10,9 +10,15 @@ data class ChallengeDetailUiState(
     val deadlineText: String = "",
     val durationDays: Int = 0,
     @DrawableRes val illustrationRes: Int = 0,
+    val goalId: Long? = null,
+    val challengeStatus: ChallengeStatus = ChallengeStatus.NotStarted,
 ) {
     val hasContent: Boolean get() = title.isNotBlank()
     val isSubGoalListEmpty: Boolean get() = subGoals.isEmpty()
+    val isChallengeStarted: Boolean get() = challengeStatus != ChallengeStatus.NotStarted
+    val isChallengeCompleted: Boolean get() = challengeStatus == ChallengeStatus.Completed
+    val canCompleteChallenge: Boolean
+        get() = subGoals.isNotEmpty() && subGoals.all(ChallengeSubGoalUi::isChecked)
 }
 
 data class ChallengeSubGoalUi(
@@ -20,3 +26,9 @@ data class ChallengeSubGoalUi(
     val title: String,
     val isChecked: Boolean = false,
 )
+
+enum class ChallengeStatus {
+    NotStarted,
+    Active,
+    Completed,
+}

--- a/app/src/main/java/be/buithg/supergoal/presentation/ui/challenges/ChallengeViewModel.kt
+++ b/app/src/main/java/be/buithg/supergoal/presentation/ui/challenges/ChallengeViewModel.kt
@@ -1,0 +1,58 @@
+package be.buithg.supergoal.presentation.ui.challenges
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import be.buithg.supergoal.domain.model.Goal
+import be.buithg.supergoal.domain.usecase.GoalUseCases
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+@HiltViewModel
+class ChallengeViewModel @Inject constructor(
+    private val goalUseCases: GoalUseCases,
+) : ViewModel() {
+
+    private val allChallenges = ChallengeDataSource.getChallenges()
+
+    private val _uiState = MutableStateFlow(
+        ChallengeListUiState(
+            challenges = allChallenges.map { challenge ->
+                ChallengeListItem(challenge = challenge, isCompleted = false)
+            },
+        ),
+    )
+    val uiState: StateFlow<ChallengeListUiState> = _uiState.asStateFlow()
+
+    init {
+        observeGoals()
+    }
+
+    private fun observeGoals() {
+        viewModelScope.launch {
+            goalUseCases.observeGoals().collect { goals ->
+                val completedTitles = goals.filter(Goal::isCompleted).map(Goal::title).toSet()
+                _uiState.value = ChallengeListUiState(
+                    challenges = allChallenges.map { challenge ->
+                        ChallengeListItem(
+                            challenge = challenge,
+                            isCompleted = completedTitles.contains(challenge.title),
+                        )
+                    },
+                )
+            }
+        }
+    }
+}
+
+data class ChallengeListUiState(
+    val challenges: List<ChallengeListItem> = emptyList(),
+)
+
+data class ChallengeListItem(
+    val challenge: Challenge,
+    val isCompleted: Boolean,
+)

--- a/app/src/main/res/layout/challenge_item_completed.xml
+++ b/app/src/main/res/layout/challenge_item_completed.xml
@@ -66,12 +66,12 @@
         android:inputType="textMultiLine"
         android:scrollHorizontally="false"
         android:singleLine="false"
-        android:text="Body"
         android:textColor="#8FFFFFFF"
         android:textSize="16sp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@+id/ivCover"
-        app:layout_constraintTop_toBottomOf="@+id/tvTitle" />
+        app:layout_constraintTop_toBottomOf="@+id/tvTitle"
+        tools:text="Body" />
 
     <TextView
         android:id="@+id/tvStatus"

--- a/app/src/main/res/layout/fragment_challenge_detail.xml
+++ b/app/src/main/res/layout/fragment_challenge_detail.xml
@@ -183,11 +183,28 @@
             </com.google.android.material.card.MaterialCardView>
 
             <com.google.android.material.button.MaterialButton
+                android:id="@+id/buttonActiv"
+                style="@style/Widget.MaterialComponents.Button.TextButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="32dp"
+                android:backgroundTint="#26F23230"
+                android:fontFamily="@font/poppins_medium"
+                android:minHeight="0dp"
+                android:paddingHorizontal="16dp"
+                android:paddingVertical="8dp"
+                android:text="@string/challenge_detail_active"
+                android:textAllCaps="false"
+                android:textColor="@android:color/white"
+                android:textSize="14sp"
+                android:visibility="gone"
+                app:cornerRadius="16dp" />
+
+            <com.google.android.material.button.MaterialButton
                 android:id="@+id/buttonStartChallenge"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="32dp"
-                android:layout_marginBottom="40dp"
+                android:layout_marginTop="16dp"
                 android:fontFamily="@font/poppins_bold"
                 android:minHeight="0dp"
                 android:paddingVertical="14dp"
@@ -197,6 +214,54 @@
                 app:cornerRadius="18dp"
                 app:iconGravity="textStart"
                 app:backgroundTint="#EE322E"
+                app:strokeColor="#4DFFFFFF"
+                app:strokeWidth="1dp" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/buttonCompleteChallenge"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:fontFamily="@font/poppins_bold"
+                android:minHeight="0dp"
+                android:paddingVertical="14dp"
+                android:text="@string/challenge_detail_complete"
+                android:textAllCaps="true"
+                android:textSize="16sp"
+                android:visibility="gone"
+                app:cornerRadius="18dp"
+                app:iconGravity="textStart"
+                app:backgroundTint="#EE322E"
+                app:strokeColor="#4DFFFFFF"
+                app:strokeWidth="1dp" />
+
+            <TextView
+                android:id="@+id/statusCompleted"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="20dp"
+                android:fontFamily="@font/poppins_bold"
+                android:text="@string/challenge_detail_completed_status"
+                android:textAllCaps="false"
+                android:textColor="#99FFFFFF"
+                android:textSize="16sp"
+                android:visibility="gone" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/buttonPerformAgain"
+                style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:layout_marginBottom="40dp"
+                android:fontFamily="@font/poppins_bold"
+                android:minHeight="0dp"
+                android:paddingVertical="14dp"
+                android:text="@string/challenge_detail_perform_again"
+                android:textAllCaps="true"
+                android:textSize="16sp"
+                android:visibility="gone"
+                app:cornerRadius="18dp"
                 app:strokeColor="#4DFFFFFF"
                 app:strokeWidth="1dp" />
         </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -69,6 +69,16 @@
     <string name="challenge_detail_start">Start Challenge</string>
     <string name="challenge_detail_toast">Challenge goal is successfully added</string>
     <string name="challenge_detail_missing">Challenge not found</string>
+    <string name="challenge_detail_complete">Complete Challenge</string>
+    <string name="challenge_detail_perform_again">Perform Again</string>
+    <string name="challenge_detail_completed_status">Challenge completed</string>
+    <string name="challenge_detail_incomplete_subgoals">Please complete all sub-goals before finishing the challenge.</string>
+    <string name="challenge_detail_reset_message">Challenge has been reset.</string>
+    <string name="challenge_detail_complete_success">Great job! Challenge completed.</string>
+    <string name="challenge_detail_goal_missing">Unable to find challenge progress. Please try again.</string>
+    <string name="challenge_detail_goal_already_started">This challenge is already active.</string>
+    <string name="challenge_detail_active">Challenge Active</string>
+    <string name="challenge_completed_status">Completed</string>
 
     <!-- Articles -->
     <string name="article_heading">Motivation Stories</string>


### PR DESCRIPTION
## Summary
- track challenge lifecycle within `ChallengeDetailViewModel`, including completion and reset actions tied to saved goals
- refresh the challenge detail UI with active, completion, and repeat controls plus supporting strings and layouts
- drive the challenge list from a new view model and swap to the completed card layout when a goal has been finished

## Testing
- ./gradlew lint *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d6259f2d90832ab502964c88e0cad4