### PR TITLE
Implement article detail navigation from motivation list

### DIFF
--- a/app/src/main/java/be/buithg/supergoal/presentation/ui/article/ArticleAdapter.kt
+++ b/app/src/main/java/be/buithg/supergoal/presentation/ui/article/ArticleAdapter.kt
@@ -5,27 +5,32 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
-import be.buithg.supergoal.databinding.ArticleItemBinding
 import be.buithg.supergoal.databinding.MotivationItemBinding
 
-class ArticleAdapter : ListAdapter<Article, ArticleAdapter.ArticleViewHolder>(ArticleDiffCallback) {
+class ArticleAdapter(
+    private val onItemClick: (Article) -> Unit,
+) : ListAdapter<Article, ArticleAdapter.ArticleViewHolder>(ArticleDiffCallback) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ArticleViewHolder {
         val inflater = LayoutInflater.from(parent.context)
         val binding = MotivationItemBinding.inflate(inflater, parent, false)
-        return ArticleViewHolder(binding)
+        return ArticleViewHolder(binding, onItemClick)
     }
 
     override fun onBindViewHolder(holder: ArticleViewHolder, position: Int) {
         holder.bind(getItem(position))
     }
 
-    class ArticleViewHolder(private val binding: MotivationItemBinding) : RecyclerView.ViewHolder(binding.root) {
+    class ArticleViewHolder(
+        private val binding: MotivationItemBinding,
+        private val onItemClick: (Article) -> Unit,
+    ) : RecyclerView.ViewHolder(binding.root) {
 
         fun bind(article: Article) {
             binding.ivCover.setImageResource(article.coverResId)
             binding.tvTitle.text = article.title
             binding.tvDeadline.text = article.content
+            binding.root.setOnClickListener { onItemClick(article) }
         }
     }
 

--- a/app/src/main/java/be/buithg/supergoal/presentation/ui/article/ArticleFragment.kt
+++ b/app/src/main/java/be/buithg/supergoal/presentation/ui/article/ArticleFragment.kt
@@ -5,13 +5,16 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
-import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.navigation.fragment.findNavController
+import androidx.navigation.fragment.navArgs
+import be.buithg.supergoal.R
 import be.buithg.supergoal.databinding.FragmentArticleBinding
 
 class ArticleFragment : Fragment() {
 
     private var _binding: FragmentArticleBinding? = null
     private val binding get() = _binding!!
+    private val args: ArticleFragmentArgs by navArgs()
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -24,6 +27,31 @@ class ArticleFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        val article = ArticleDataSource.getArticles().firstOrNull { it.id == args.articleId }
+
+        binding.apply {
+            if (article != null) {
+                tvArticleTitle.text = article.title
+                tvArticleContent.text = article.content
+                ivArticleCover.setImageResource(article.coverResId)
+                ivArticleCover.visibility = View.VISIBLE
+                ivArticleCover.contentDescription = article.title
+            } else {
+                tvArticleTitle.text = getString(R.string.article_not_found_title)
+                tvArticleContent.text = getString(R.string.article_not_found_message)
+                ivArticleCover.setImageDrawable(null)
+                ivArticleCover.visibility = View.GONE
+            }
+
+            tvBack.setOnClickListener {
+                findNavController().navigateUp()
+            }
+        }
     }
 
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
 }

--- a/app/src/main/java/be/buithg/supergoal/presentation/ui/motivation/MotivationFragment.kt
+++ b/app/src/main/java/be/buithg/supergoal/presentation/ui/motivation/MotivationFragment.kt
@@ -5,9 +5,8 @@ import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
-import be.buithg.supergoal.R
-import be.buithg.supergoal.databinding.FragmentArticleBinding
 import be.buithg.supergoal.databinding.FragmentMotivationBinding
 import be.buithg.supergoal.presentation.ui.article.ArticleAdapter
 import be.buithg.supergoal.presentation.ui.article.ArticleDataSource
@@ -24,7 +23,7 @@ class MotivationFragment : Fragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        _binding = FragmentMotivationBinding.inflate(inflater,container,false)
+        _binding = FragmentMotivationBinding.inflate(inflater, container, false)
         return binding.root
     }
 
@@ -42,7 +41,10 @@ class MotivationFragment : Fragment() {
     }
 
     private fun setupRecyclerView() {
-        articleAdapter = ArticleAdapter()
+        articleAdapter = ArticleAdapter { article ->
+            val action = MotivationFragmentDirections.actionMotivationFragmentToNavArticle(article.id)
+            findNavController().navigate(action)
+        }
         binding.rvMotivations.apply {
             layoutManager = LinearLayoutManager(requireContext())
             adapter = articleAdapter

--- a/app/src/main/res/layout/fragment_article.xml
+++ b/app/src/main/res/layout/fragment_article.xml
@@ -15,32 +15,39 @@
         android:orientation="vertical">
 
         <TextView
+            android:id="@+id/tvBack"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
+            android:layout_height="wrap_content"
             android:layout_marginTop="10dp"
-            android:layout_weight="700"
             android:drawableStart="@drawable/back_ic"
             android:drawablePadding="10dp"
             android:fontFamily="@font/poppins_bold"
-            android:text="Back"
+            android:gravity="center_vertical"
+            android:paddingVertical="8dp"
+            android:text="@string/article_back"
             android:textColor="@color/white"
-            android:textSize="16sp" />
+            android:textSize="16sp"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:clickable="true"
+            android:focusable="true" />
 
         <TextView
             android:id="@+id/tvMyGoals"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:fontFamily="@font/poppins_extra_bold"
-            android:text="Article"
+            android:text="@string/article_heading"
             android:textColor="@android:color/white"
             android:textSize="40sp" />
 
 
         <com.google.android.material.imageview.ShapeableImageView
+            android:id="@+id/ivArticleCover"
             android:layout_width="match_parent"
             android:layout_height="160dp"
             android:scaleType="centerCrop"
             android:src="@drawable/article_im"
+            android:contentDescription="@string/article_cover_content_description"
             app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.App.Article"
             app:strokeColor="#F23230"
             app:strokeWidth="2dp" />
@@ -55,19 +62,24 @@
             android:padding="20dp">
 
             <TextView
-                android:layout_width="wrap_content"
+                android:id="@+id/tvArticleTitle"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:fontFamily="@font/poppins_extra_bold"
-                android:text="Orion Varela: The Quiet Rise"
+                android:text="@string/article_heading"
                 android:textColor="@color/white"
-                android:textSize="20sp" />
+                android:textSize="20sp"
+                tools:text="Orion Varela: The Quiet Rise" />
 
             <TextView
-                android:layout_width="wrap_content"
+                android:id="@+id/tvArticleContent"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:textColor="#D8FFFFFF"
+                android:layout_marginTop="12dp"
                 android:fontFamily="@font/poppins_regular"
-                android:text="I grew up in a coastal town where the wind never rested. The ball skipped across concrete and sand, and every bounce tried to trick me. I used to believe talent was something you found, like a coin on the beach. It took me years to learn that talent is mostly repetition that refuses to be boring. On training days I arrived early and I left late. "/>
+                android:textColor="#D8FFFFFF"
+                android:textSize="16sp"
+                tools:text="I grew up in a coastal town where the wind never rested..." />
         </LinearLayout>
     </LinearLayout>
 

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -44,7 +44,12 @@
         android:id="@+id/nav_article"
         android:name="be.buithg.supergoal.presentation.ui.article.ArticleFragment"
         android:label="fragment_article"
-        tools:layout="@layout/fragment_article" />
+        tools:layout="@layout/fragment_article">
+        <argument
+            android:name="articleId"
+            app:argType="integer"
+            android:defaultValue="-1" />
+    </fragment>
 
     <fragment
         android:id="@+id/nav_analytics"
@@ -98,5 +103,9 @@
         android:id="@+id/motivationFragment"
         android:name="be.buithg.supergoal.presentation.ui.motivation.MotivationFragment"
         android:label="fragment_motivation"
-        tools:layout="@layout/fragment_motivation" />
+        tools:layout="@layout/fragment_motivation">
+        <action
+            android:id="@+id/action_motivationFragment_to_nav_article"
+            app:destination="@id/nav_article" />
+    </fragment>
 </navigation>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -73,4 +73,7 @@
     <!-- Articles -->
     <string name="article_heading">Motivation Stories</string>
     <string name="article_cover_content_description">Article cover image</string>
+    <string name="article_back">Back</string>
+    <string name="article_not_found_title">Article not found</string>
+    <string name="article_not_found_message">We couldn&#39;t load this story. Please try again later.</string>
 </resources>


### PR DESCRIPTION
## Summary
- wire up the motivation list to open the article detail screen for the selected story
- load article content via Safe Args and refresh the detail layout/back interaction
- add navigation arguments and fallback copy to support missing article states

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d627b34a08832abe204605ad51865d