### PR TITLE
Add refreshable motivational quotes

### DIFF
--- a/app/src/main/java/be/buithg/supergoal/presentation/ui/motivation/MotivationFragment.kt
+++ b/app/src/main/java/be/buithg/supergoal/presentation/ui/motivation/MotivationFragment.kt
@@ -10,6 +10,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import be.buithg.supergoal.databinding.FragmentMotivationBinding
 import be.buithg.supergoal.presentation.ui.article.ArticleAdapter
 import be.buithg.supergoal.presentation.ui.article.ArticleDataSource
+import kotlin.random.Random
 
 class MotivationFragment : Fragment() {
 
@@ -17,6 +18,130 @@ class MotivationFragment : Fragment() {
     private val binding get() = _binding!!
 
     private lateinit var articleAdapter: ArticleAdapter
+    private var lastQuoteIndex: Int = -1
+
+    private val motivationQuotes = listOf(
+        MotivationQuote(
+            text = "“Train for the ninety, prepare for the ninety-first.”",
+            author = "— Marco Vale, Striker"
+        ),
+        MotivationQuote(
+            text = "“First touch calms the ball; belief calms the storm.”",
+            author = "— Elias Kade, Midfielder"
+        ),
+        MotivationQuote(
+            text = "“We chase the ball, but we win the day with habits.”",
+            author = "— Tomas Riera, Right Back"
+        ),
+        MotivationQuote(
+            text = "“Sprint with your legs, recover with your mind.”",
+            author = "— Luka Dervič, Winger"
+        ),
+        MotivationQuote(
+            text = "“Pressure is just the crowd inside your head.”",
+            author = "— Rafael Monte, Goalkeeper"
+        ),
+        MotivationQuote(
+            text = "“Miss, learn, demand the next pass.”",
+            author = "— Jonas Krell, Forward"
+        ),
+        MotivationQuote(
+            text = "“Champions show up before the sun and stay after the lights.”",
+            author = "— Victor Anoba, Centre-Back"
+        ),
+        MotivationQuote(
+            text = "“Your lungs set limits; your purpose moves them.”",
+            author = "— Niko Saar, Defensive Midfielder"
+        ),
+        MotivationQuote(
+            text = "“Quality is repetition done with respect.”",
+            author = "— Matteo Lora, Playmaker"
+        ),
+        MotivationQuote(
+            text = "“Run the extra five yards; titles hide there.”",
+            author = "— Pierre Dumez, Left Back"
+        ),
+        MotivationQuote(
+            text = "“Make the pass you wish someone had made to you.”",
+            author = "— Javier Roa, No. 10"
+        ),
+        MotivationQuote(
+            text = "“Composure is speed that refuses to panic.”",
+            author = "— Alexi Byrne, Striker"
+        ),
+        MotivationQuote(
+            text = "“If your touch is honest, the game forgives a lot.”",
+            author = "— Bruno Caetano, Wing-Back"
+        ),
+        MotivationQuote(
+            text = "“Sweat is the ink; the season writes in it.”",
+            author = "— Ilias Mour, Centre-Mid"
+        ),
+        MotivationQuote(
+            text = "“Drills build trust so instincts can be brave.”",
+            author = "— Daniel Hoene, Keeper"
+        ),
+        MotivationQuote(
+            text = "“You can’t fake work when the ball rolls.”",
+            author = "— Sergi Valdés, Holding Mid"
+        ),
+        MotivationQuote(
+            text = "“We don’t chase luck; we create angles for it.”",
+            author = "— Karim Fadil, Forward"
+        ),
+        MotivationQuote(
+            text = "“Silence the noise with one clean first touch.”",
+            author = "— Pavel Rusan, Centre-Back"
+        ),
+        MotivationQuote(
+            text = "“The badge is heavy—carry it with small daily wins.”",
+            author = "— Andrej Kovik, Captain"
+        ),
+        MotivationQuote(
+            text = "“Aim for the far post; live for the next run.”",
+            author = "— Diego Navas, Striker"
+        ),
+        MotivationQuote(
+            text = "“Be humble in victory and curious in defeat.”",
+            author = "— Mateo Zoric, Midfielder"
+        ),
+        MotivationQuote(
+            text = "“Fitness fades; discipline survives extra time.”",
+            author = "— Leon Varga, Full-Back"
+        ),
+        MotivationQuote(
+            text = "“Talk less to the fear, more to the ball.”",
+            author = "— Hugo Maret, Winger"
+        ),
+        MotivationQuote(
+            text = "“Decision beats distance.”",
+            author = "— Kaito Morita, Playmaker"
+        ),
+        MotivationQuote(
+            text = "“Your off-the-ball runs tell the truth about you.”",
+            author = "— Omar Benali, Forward"
+        ),
+        MotivationQuote(
+            text = "“Big games reward small details done early.”",
+            author = "— Stefan Groh, Centre-Back"
+        ),
+        MotivationQuote(
+            text = "“Recovery is training in quieter clothes.”",
+            author = "— Yassin Ferou, Keeper"
+        ),
+        MotivationQuote(
+            text = "“We share the ball and multiply courage.”",
+            author = "— Emil Petrescu, Midfielder"
+        ),
+        MotivationQuote(
+            text = "“Plan the press, then trust the chaos.”",
+            author = "— Rohan Dev, Wing-Back"
+        ),
+        MotivationQuote(
+            text = "“Dream big, but keep your studs grounded.”",
+            author = "— Luca Parisi, Striker"
+        )
+    )
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -31,11 +156,14 @@ class MotivationFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
         setupRecyclerView()
         articleAdapter.submitList(ArticleDataSource.getArticles())
+        binding.btnRefreshQuote.setOnClickListener { displayRandomQuote() }
+        displayRandomQuote()
 
     }
 
     override fun onDestroyView() {
         super.onDestroyView()
+        binding.btnRefreshQuote.setOnClickListener(null)
         binding.rvMotivations.adapter = null
         _binding = null
     }
@@ -50,4 +178,21 @@ class MotivationFragment : Fragment() {
             adapter = articleAdapter
         }
     }
+
+    private fun displayRandomQuote() {
+        if (motivationQuotes.isEmpty()) return
+        var newIndex: Int
+        do {
+            newIndex = Random.nextInt(motivationQuotes.size)
+        } while (motivationQuotes.size > 1 && newIndex == lastQuoteIndex)
+        lastQuoteIndex = newIndex
+        val quote = motivationQuotes[newIndex]
+        binding.tvQuote.text = quote.text
+        binding.tvQuoteAuthor.text = quote.author
+    }
 }
+
+private data class MotivationQuote(
+    val text: String,
+    val author: String
+)

--- a/app/src/main/res/layout/fragment_motivation.xml
+++ b/app/src/main/res/layout/fragment_motivation.xml
@@ -42,17 +42,18 @@
                 android:layout_height="wrap_content">
 
                 <TextView
+                    android:id="@+id/tvQuote"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:textSize="18sp"
                     android:textColor="@color/white"
-                    android:textAllCaps="true"
                     android:layout_marginTop="15dp"
                     android:layout_marginBottom="15dp"
                     android:fontFamily="@font/poppins_bold"
                     android:text="“Train for the ninety, prepare for the ninety-first.”"/>
-                
+
                 <TextView
+                    android:id="@+id/tvQuoteAuthor"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="— Marco Vale, Striker"
@@ -63,11 +64,16 @@
             </LinearLayout>
 
             <ImageView
+                android:id="@+id/btnRefreshQuote"
                 android:layout_width="50dp"
                 android:layout_height="50dp"
                 android:layout_gravity="end|bottom"
-
-                android:src="@drawable/recycle_ic"/>
+                android:contentDescription="@string/motivation_refresh_content_description"
+                android:src="@drawable/recycle_ic"
+                android:background="?attr/selectableItemBackgroundBorderless"
+                android:padding="8dp"
+                android:clickable="true"
+                android:focusable="true"/>
         </FrameLayout>
 
         <androidx.recyclerview.widget.RecyclerView

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -86,4 +86,5 @@
     <string name="article_back">Back</string>
     <string name="article_not_found_title">Article not found</string>
     <string name="article_not_found_message">We couldn t load this story. Please try again later.</string>
+    <string name="motivation_refresh_content_description">Refresh motivation quote</string>
 </resources>


### PR DESCRIPTION
## Summary
- add the full set of motivational quotes to the motivation screen
- enable refreshing the featured quote via the recycle button with non-repeating random selection
- improve accessibility by providing a content description for the refresh control

## Testing
- ./gradlew test *(fails: Android SDK not configured in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d64cf3f858832aa8cecdf93e75e415