### PR TITLE
Implement settings screen actions and placeholder pages

### DIFF
--- a/app/src/main/java/be/buithg/supergoal/presentation/ui/settings/SettingsFragment.kt
+++ b/app/src/main/java/be/buithg/supergoal/presentation/ui/settings/SettingsFragment.kt
@@ -1,25 +1,90 @@
 package be.buithg.supergoal.presentation.ui.settings
 
+import android.content.ActivityNotFoundException
+import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
-import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.annotation.StringRes
+import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.findNavController
 import be.buithg.supergoal.R
-import be.buithg.supergoal.databinding.FragmentOnBoardingBinding
 import be.buithg.supergoal.databinding.FragmentSettingsBinding
 
 class SettingsFragment : Fragment() {
 
-    private lateinit var binding: FragmentSettingsBinding
+    private var _binding: FragmentSettingsBinding? = null
+    private val binding get() = _binding!!
 
     override fun onCreateView(
-        inflater: LayoutInflater, container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View? {
-        binding = FragmentSettingsBinding.inflate(inflater, container, false)
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        _binding = FragmentSettingsBinding.inflate(inflater, container, false)
         return binding.root
     }
 
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
 
+        binding.apply {
+            btnShareApp.setOnClickListener { shareApp() }
+            btnRateUs.setOnClickListener { rateApp() }
+            btnPrivacyPolicy.setOnClickListener {
+                openStaticPage(R.string.settings_privacy_policy_title)
+            }
+            btnTermsAndConditions.setOnClickListener {
+                openStaticPage(R.string.settings_terms_title)
+            }
+        }
+    }
+
+    private fun shareApp() {
+        val context = requireContext()
+        val packageName = context.packageName
+        val shareIntent = Intent(Intent.ACTION_SEND).apply {
+            type = "text/plain"
+            putExtra(
+                Intent.EXTRA_TEXT,
+                context.getString(
+                    R.string.settings_share_message,
+                    packageName,
+                ),
+            )
+        }
+        startActivity(
+            Intent.createChooser(
+                shareIntent,
+                context.getString(R.string.settings_share_chooser_title),
+            ),
+        )
+    }
+
+    private fun rateApp() {
+        val context = requireContext()
+        val packageName = context.packageName
+        val marketUri = Uri.parse("market://details?id=$packageName")
+        val marketIntent = Intent(Intent.ACTION_VIEW, marketUri)
+        try {
+            startActivity(marketIntent)
+        } catch (e: ActivityNotFoundException) {
+            val webUri = Uri.parse("https://play.google.com/store/apps/details?id=$packageName")
+            startActivity(Intent(Intent.ACTION_VIEW, webUri))
+        }
+    }
+
+    private fun openStaticPage(@StringRes titleRes: Int) {
+        val action = SettingsFragmentDirections.actionNavSettingsToStaticPageFragment(
+            getString(titleRes),
+        )
+        findNavController().navigate(action)
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
 }

--- a/app/src/main/java/be/buithg/supergoal/presentation/ui/settings/StaticPageFragment.kt
+++ b/app/src/main/java/be/buithg/supergoal/presentation/ui/settings/StaticPageFragment.kt
@@ -1,0 +1,35 @@
+package be.buithg.supergoal.presentation.ui.settings
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.navArgs
+import be.buithg.supergoal.databinding.FragmentStaticPageBinding
+
+class StaticPageFragment : Fragment() {
+
+    private var _binding: FragmentStaticPageBinding? = null
+    private val binding get() = _binding!!
+    private val args: StaticPageFragmentArgs by navArgs()
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        _binding = FragmentStaticPageBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        binding.tvTitle.text = args.pageTitle
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -11,71 +11,76 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:orientation="vertical">
-    <TextView
-        android:id="@+id/tvMyGoals"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="20dp"
-        android:layout_marginTop="20dp"
-        android:fontFamily="@font/poppins_extra_bold"
-        android:text="Settings"
-        android:layout_marginBottom="30dp"
-        android:textAllCaps="true"
-        android:textColor="@android:color/white"
-        android:textSize="40sp" />
 
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:gravity="center"
-        android:layout_marginTop="30dp"
-        android:layout_marginHorizontal="10dp"
-        android:orientation="vertical">
+        <TextView
+            android:id="@+id/tvMyGoals"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="20dp"
+            android:layout_marginTop="20dp"
+            android:layout_marginBottom="30dp"
+            android:fontFamily="@font/poppins_extra_bold"
+            android:text="@string/settings_title"
+            android:textAllCaps="true"
+            android:textColor="@android:color/white"
+            android:textSize="40sp" />
 
-    <com.google.android.material.button.MaterialButton
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginHorizontal="50dp"
-        android:backgroundTint="#EE322E"
-        android:fontFamily="@font/poppins_bold"
-        android:paddingVertical="10dp"
-        android:text="Share the App"
-        android:textSize="16sp" />
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="10dp"
+            android:layout_marginTop="30dp"
+            android:gravity="center"
+            android:orientation="vertical">
 
-    <com.google.android.material.button.MaterialButton
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginHorizontal="50dp"
-        android:layout_marginTop="30dp"
-        android:backgroundTint="#EE322E"
-        android:fontFamily="@font/poppins_bold"
-        android:paddingVertical="10dp"
-        android:text="Rate Us"
-        android:textSize="16sp" />
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btnShareApp"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="50dp"
+                android:backgroundTint="#EE322E"
+                android:fontFamily="@font/poppins_bold"
+                android:paddingVertical="10dp"
+                android:text="@string/settings_share_the_app"
+                android:textSize="16sp" />
 
-    <com.google.android.material.button.MaterialButton
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginHorizontal="50dp"
-        android:layout_marginTop="30dp"
-        android:backgroundTint="#EE322E"
-        android:fontFamily="@font/poppins_bold"
-        android:paddingVertical="10dp"
-        android:text="Privacy Policy"
-        android:textSize="16sp" />
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btnRateUs"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="50dp"
+                android:layout_marginTop="30dp"
+                android:backgroundTint="#EE322E"
+                android:fontFamily="@font/poppins_bold"
+                android:paddingVertical="10dp"
+                android:text="@string/settings_rate_us"
+                android:textSize="16sp" />
 
-    <com.google.android.material.button.MaterialButton
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginHorizontal="50dp"
-        android:layout_marginTop="30dp"
-        android:backgroundTint="#EE322E"
-        android:fontFamily="@font/poppins_bold"
-        android:paddingVertical="10dp"
-        android:text="Terms and Conditions"
-        android:textSize="16sp" />
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btnPrivacyPolicy"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="50dp"
+                android:layout_marginTop="30dp"
+                android:backgroundTint="#EE322E"
+                android:fontFamily="@font/poppins_bold"
+                android:paddingVertical="10dp"
+                android:text="@string/settings_privacy_policy"
+                android:textSize="16sp" />
 
-    </LinearLayout>
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btnTermsAndConditions"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="50dp"
+                android:layout_marginTop="30dp"
+                android:backgroundTint="#EE322E"
+                android:fontFamily="@font/poppins_bold"
+                android:paddingVertical="10dp"
+                android:text="@string/settings_terms_and_conditions"
+                android:textSize="16sp" />
+
+        </LinearLayout>
     </LinearLayout>
 
 </ScrollView>

--- a/app/src/main/res/layout/fragment_static_page.xml
+++ b/app/src/main/res/layout/fragment_static_page.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@drawable/settings_bg"
+    tools:context=".presentation.ui.settings.StaticPageFragment">
+
+    <TextView
+        android:id="@+id/tvTitle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="24dp"
+        android:layout_marginTop="32dp"
+        android:fontFamily="@font/poppins_extra_bold"
+        android:textColor="@android:color/white"
+        android:textSize="32sp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="Privacy Policy" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -67,7 +67,22 @@
         android:id="@+id/nav_settings"
         android:name="be.buithg.supergoal.presentation.ui.settings.SettingsFragment"
         android:label="fragment_settings"
-        tools:layout="@layout/fragment_settings" />
+        tools:layout="@layout/fragment_settings">
+        <action
+            android:id="@+id/action_nav_settings_to_staticPageFragment"
+            app:destination="@id/staticPageFragment" />
+    </fragment>
+
+    <fragment
+        android:id="@+id/staticPageFragment"
+        android:name="be.buithg.supergoal.presentation.ui.settings.StaticPageFragment"
+        android:label="fragment_static_page"
+        tools:layout="@layout/fragment_static_page">
+        <argument
+            android:name="pageTitle"
+            app:argType="string"
+            android:defaultValue="" />
+    </fragment>
 
     <fragment
         android:id="@+id/addGoalFragment"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,6 +4,15 @@
     <string name="onboarding_subtitle">Chart your constellations of skills, practice in short bursts, and collect stars as you grow.</string>
     <string name="onboarding_cta">Get Started</string>
     <string name="hello_blank_fragment">Hello blank fragment</string>
+    <string name="settings_title">Settings</string>
+    <string name="settings_share_the_app">Share the App</string>
+    <string name="settings_rate_us">Rate Us</string>
+    <string name="settings_privacy_policy">Privacy Policy</string>
+    <string name="settings_terms_and_conditions">Terms and Conditions</string>
+    <string name="settings_share_message">Achieve your goals with SuperGoal app: http://play.google.com/store/apps/details?id=%1$s</string>
+    <string name="settings_share_chooser_title">Share SuperGoal</string>
+    <string name="settings_privacy_policy_title">Privacy Policy</string>
+    <string name="settings_terms_title">Terms and Conditions</string>
 
     <!-- Add Goal -->
     <string name="my_goals">MY GOALS</string>


### PR DESCRIPTION
## Summary
- hook up the settings buttons to share the app, rate it on Google Play, or open placeholder pages
- add a reusable static page fragment and layout to show blank screens for privacy policy and terms
- update navigation and string resources to support the new settings actions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d64d201aa0832ab6f40e8b08dc2191