### PR TITLE
Fix MaterialCheckBox tint in challenge detail

### DIFF
--- a/app/src/main/java/be/buithg/supergoal/presentation/ui/challenges/ChallengeSubGoalAdapter.kt
+++ b/app/src/main/java/be/buithg/supergoal/presentation/ui/challenges/ChallengeSubGoalAdapter.kt
@@ -36,6 +36,10 @@ class ChallengeSubGoalAdapter(
                 root.context,
                 R.color.selector_checkbox_tint,
             )
+            checkSubGoal.checkedIconTintList = AppCompatResources.getColorStateList(
+                root.context,
+                R.color.selector_checkbox_icon_tint,
+            )
             checkSubGoal.setOnCheckedChangeListener { _, isChecked ->
                 onCheckedChange(item.id, isChecked)
             }

--- a/app/src/main/res/color/selector_checkbox_icon_tint.xml
+++ b/app/src/main/res/color/selector_checkbox_icon_tint.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_checked="true" android:color="#FFFFFFFF" />
+    <item android:color="@android:color/transparent" />
+</selector>

--- a/app/src/main/res/layout/item_challenge_subgoal.xml
+++ b/app/src/main/res/layout/item_challenge_subgoal.xml
@@ -15,7 +15,8 @@
         android:paddingVertical="8dp"
         android:textColor="@android:color/white"
         android:textSize="16sp"
-        app:useMaterialThemeColors="false"
-        android:buttonTint="@color/selector_checkbox_tint" />
+        app:buttonTint="@color/selector_checkbox_tint"
+        app:checkedIconTint="@color/selector_checkbox_icon_tint"
+        app:useMaterialThemeColors="false" />
 
 </LinearLayout>


### PR DESCRIPTION
## Summary
- ensure challenge subgoal checkboxes keep a white check icon by applying separate icon tinting
- add a dedicated color state list and reference it from the layout and adapter

## Testing
- ./gradlew lint *(fails: Android SDK missing in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6517918dc832a93b712850b10c47e