### PR TITLE
Use active challenge layout for active challenges

### DIFF
--- a/app/src/main/java/be/buithg/supergoal/presentation/ui/challenges/ChallengeAdapter.kt
+++ b/app/src/main/java/be/buithg/supergoal/presentation/ui/challenges/ChallengeAdapter.kt
@@ -7,6 +7,7 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import be.buithg.supergoal.R
+import be.buithg.supergoal.databinding.ChallengeItemActivBinding
 import be.buithg.supergoal.databinding.ChallengeItemBinding
 import be.buithg.supergoal.databinding.ChallengeItemCompletedBinding
 
@@ -15,20 +16,29 @@ class ChallengeAdapter(
 ) : ListAdapter<ChallengeListItem, RecyclerView.ViewHolder>(DiffCallback) {
 
     override fun getItemViewType(position: Int): Int =
-        if (getItem(position).status == ChallengeStatus.Completed) {
-            VIEW_TYPE_COMPLETED
-        } else {
-            VIEW_TYPE_DEFAULT
+        when (getItem(position).status) {
+            ChallengeStatus.Completed -> VIEW_TYPE_COMPLETED
+            ChallengeStatus.Active -> VIEW_TYPE_ACTIVE
+            ChallengeStatus.NotStarted -> VIEW_TYPE_DEFAULT
         }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
         val inflater = LayoutInflater.from(parent.context)
-        return if (viewType == VIEW_TYPE_COMPLETED) {
-            val binding = ChallengeItemCompletedBinding.inflate(inflater, parent, false)
-            CompletedViewHolder(binding, onChallengeClick)
-        } else {
-            val binding = ChallengeItemBinding.inflate(inflater, parent, false)
-            ChallengeViewHolder(binding, onChallengeClick)
+        return when (viewType) {
+            VIEW_TYPE_COMPLETED -> {
+                val binding = ChallengeItemCompletedBinding.inflate(inflater, parent, false)
+                CompletedViewHolder(binding, onChallengeClick)
+            }
+
+            VIEW_TYPE_ACTIVE -> {
+                val binding = ChallengeItemActivBinding.inflate(inflater, parent, false)
+                ActiveViewHolder(binding, onChallengeClick)
+            }
+
+            else -> {
+                val binding = ChallengeItemBinding.inflate(inflater, parent, false)
+                ChallengeViewHolder(binding, onChallengeClick)
+            }
         }
     }
 
@@ -36,6 +46,7 @@ class ChallengeAdapter(
         val item = getItem(position)
         when (holder) {
             is ChallengeViewHolder -> holder.bind(item)
+            is ActiveViewHolder -> holder.bind(item)
             is CompletedViewHolder -> holder.bind(item)
         }
     }
@@ -56,12 +67,31 @@ class ChallengeAdapter(
                 challenge.durationDays,
             )
 
-            val isActive = item.status == ChallengeStatus.Active
-            btnAddGoal.isVisible = !isActive
-//            statusActive.isVisible = isActive
+            btnAddGoal.isVisible = true
 
             root.setOnClickListener { onChallengeClick(challenge) }
             btnAddGoal.setOnClickListener { onChallengeClick(challenge) }
+        }
+    }
+
+    class ActiveViewHolder(
+        private val binding: ChallengeItemActivBinding,
+        private val onChallengeClick: (Challenge) -> Unit,
+    ) : RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(item: ChallengeListItem) = with(binding) {
+            val challenge = item.challenge
+            ivCover.setImageResource(challenge.imageRes)
+            tvTitle.text = challenge.title
+            tvCategory.text = root.context.getString(R.string.challenge_category_format, challenge.category)
+            tvCompletionTime.text = root.resources.getQuantityString(
+                R.plurals.challenge_completion_time,
+                challenge.durationDays,
+                challenge.durationDays,
+            )
+            statusActive.text = root.context.getString(R.string.challenge_detail_active)
+
+            root.setOnClickListener { onChallengeClick(challenge) }
         }
     }
 
@@ -91,5 +121,6 @@ class ChallengeAdapter(
     private companion object {
         const val VIEW_TYPE_DEFAULT = 0
         const val VIEW_TYPE_COMPLETED = 1
+        const val VIEW_TYPE_ACTIVE = 2
     }
 }


### PR DESCRIPTION
## Summary
- render active challenges with the dedicated `challenge_item_activ` layout in the list
- add a view holder for the active state and ensure the status label uses the localized string

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6566a36b4832a9d97e26aaabb2b08