### PR TITLE
Ensure challenge goals keep illustration

### DIFF
--- a/app/src/main/java/be/buithg/supergoal/presentation/ui/challenges/ChallengeDetailViewModel.kt
+++ b/app/src/main/java/be/buithg/supergoal/presentation/ui/challenges/ChallengeDetailViewModel.kt
@@ -1,9 +1,12 @@
 package be.buithg.supergoal.presentation.ui.challenges
 
+import android.content.ContentResolver
+import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import be.buithg.supergoal.BuildConfig
 import be.buithg.supergoal.R
 import be.buithg.supergoal.domain.model.Goal
 import be.buithg.supergoal.domain.model.GoalCategory
@@ -115,7 +118,7 @@ class ChallengeDetailViewModel @Inject constructor(
             title = challenge.title,
             category = GoalCategory.fromRaw(challenge.category),
             deadlineMillis = deadlineMillis,
-            imageUri = null,
+            imageUri = toResourceUri(challenge.imageRes),
             createdAtMillis = System.currentTimeMillis(),
             subGoals = challenge.subgoals.map { title -> SubGoal(title = title) },
         )
@@ -310,6 +313,11 @@ class ChallengeDetailViewModel @Inject constructor(
 
     private fun sendEvent(event: ChallengeDetailEvent) {
         eventsChannel.trySend(event)
+    }
+
+    private fun toResourceUri(@DrawableRes imageRes: Int): String? {
+        if (imageRes == 0) return null
+        return "${ContentResolver.SCHEME_ANDROID_RESOURCE}://${BuildConfig.APPLICATION_ID}/$imageRes"
     }
 
     private fun syncActiveGoal(subGoals: List<ChallengeSubGoalUi>): Goal? {

--- a/app/src/main/java/be/buithg/supergoal/presentation/ui/goal/AddGoalFragment.kt
+++ b/app/src/main/java/be/buithg/supergoal/presentation/ui/goal/AddGoalFragment.kt
@@ -3,6 +3,7 @@ package be.buithg.supergoal.presentation.ui.goal
 import CategoryAdapter
 import android.animation.ValueAnimator
 import android.app.DatePickerDialog
+import android.content.ContentResolver
 import android.content.Intent
 import android.graphics.Color
 import android.net.Uri
@@ -242,15 +243,26 @@ class AddGoalFragment : Fragment() {
             photoPlaceholder.isVisible = true
         } else if (displayedImageUri != imageUri) {
             val parsedUri = runCatching { Uri.parse(imageUri) }.getOrNull()
-            if (parsedUri != null) {
-                displayedImageUri = imageUri
-                photoPreview.setImageURI(null)
-                photoPreview.setImageURI(parsedUri)
-                photoPlaceholder.isVisible = false
-            } else {
-                displayedImageUri = null
-                photoPreview.setImageDrawable(null)
-                photoPlaceholder.isVisible = true
+            val isResourceUri = parsedUri?.scheme == ContentResolver.SCHEME_ANDROID_RESOURCE
+            val resourceId = if (isResourceUri) parsedUri?.lastPathSegment?.toIntOrNull() else null
+            when {
+                resourceId != null -> {
+                    displayedImageUri = imageUri
+                    photoPreview.setImageDrawable(null)
+                    photoPreview.setImageResource(resourceId)
+                    photoPlaceholder.isVisible = false
+                }
+                parsedUri != null -> {
+                    displayedImageUri = imageUri
+                    photoPreview.setImageURI(null)
+                    photoPreview.setImageURI(parsedUri)
+                    photoPlaceholder.isVisible = false
+                }
+                else -> {
+                    displayedImageUri = null
+                    photoPreview.setImageDrawable(null)
+                    photoPlaceholder.isVisible = true
+                }
             }
         }
     }

--- a/app/src/main/java/be/buithg/supergoal/presentation/ui/goal/GoalAdapter.kt
+++ b/app/src/main/java/be/buithg/supergoal/presentation/ui/goal/GoalAdapter.kt
@@ -1,5 +1,6 @@
 package be.buithg.supergoal.presentation.ui.goal
 
+import android.content.ContentResolver
 import android.net.Uri
 import android.view.LayoutInflater
 import android.view.ViewGroup
@@ -37,11 +38,15 @@ class GoalAdapter(
 
             if (!item.imageUri.isNullOrBlank()) {
                 val uri = runCatching { Uri.parse(item.imageUri) }.getOrNull()
-                if (uri != null) {
-                    ivCover.setImageURI(null)
-                    ivCover.setImageURI(uri)
-                } else {
-                    ivCover.setImageResource(R.drawable.ic_launcher_background)
+                val isResourceUri = uri?.scheme == ContentResolver.SCHEME_ANDROID_RESOURCE
+                val resourceId = if (isResourceUri) uri?.lastPathSegment?.toIntOrNull() else null
+                when {
+                    resourceId != null -> ivCover.setImageResource(resourceId)
+                    uri != null -> {
+                        ivCover.setImageURI(null)
+                        ivCover.setImageURI(uri)
+                    }
+                    else -> ivCover.setImageResource(R.drawable.ic_launcher_background)
                 }
             } else {
                 ivCover.setImageResource(R.drawable.ic_launcher_background)

--- a/app/src/main/java/be/buithg/supergoal/presentation/ui/goal/GoalDetailFragment.kt
+++ b/app/src/main/java/be/buithg/supergoal/presentation/ui/goal/GoalDetailFragment.kt
@@ -1,5 +1,6 @@
 package be.buithg.supergoal.presentation.ui.goal
 
+import android.content.ContentResolver
 import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -142,15 +143,26 @@ class GoalDetailFragment : Fragment() {
             photoPreview.isVisible = true
         } else if (displayedImageUri != state.imageUri) {
             val uri = runCatching { Uri.parse(state.imageUri) }.getOrNull()
-            if (uri != null) {
-                displayedImageUri = state.imageUri
-                photoPreview.setImageURI(null)
-                photoPreview.setImageURI(uri)
-                photoPreview.isVisible = false
-            } else {
-                displayedImageUri = null
-                photoPreview.setImageDrawable(null)
-                photoPreview.isVisible = true
+            val isResourceUri = uri?.scheme == ContentResolver.SCHEME_ANDROID_RESOURCE
+            val resourceId = if (isResourceUri) uri?.lastPathSegment?.toIntOrNull() else null
+            when {
+                resourceId != null -> {
+                    displayedImageUri = state.imageUri
+                    photoPreview.setImageDrawable(null)
+                    photoPreview.setImageResource(resourceId)
+                    photoPreview.isVisible = false
+                }
+                uri != null -> {
+                    displayedImageUri = state.imageUri
+                    photoPreview.setImageURI(null)
+                    photoPreview.setImageURI(uri)
+                    photoPreview.isVisible = false
+                }
+                else -> {
+                    displayedImageUri = null
+                    photoPreview.setImageDrawable(null)
+                    photoPreview.isVisible = true
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- persist challenge illustration when converting it into a goal by storing a resource URI
- load drawable resource URIs across add/edit screens, goal list, and goal details
- keep fallbacks to the default placeholder when an image cannot be resolved

## Testing
- ./gradlew test *(fails: Android SDK not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d65ea8e1a8832a9f127f2633096618