### PR TITLE
Adjust analytics empty state visibility

### DIFF
--- a/app/src/main/java/be/buithg/supergoal/presentation/ui/analytic/AnalyticFragment.kt
+++ b/app/src/main/java/be/buithg/supergoal/presentation/ui/analytic/AnalyticFragment.kt
@@ -57,8 +57,9 @@ class AnalyticFragment : Fragment() {
     }
 
     private fun renderState(state: AnalyticUiState) = with(binding) {
-        overallContainer.isVisible = state.hasOverallProgress
-//        tvOverallEmpty.isVisible = !state.hasOverallProgress
+        val hasOverallProgress = state.hasOverallProgress
+        overallContainer.isVisible = hasOverallProgress
+        tvOverallHeader.isVisible = hasOverallProgress
 
         if (state.hasOverallProgress) {
             val completedPercent = state.overallProgress.coerceIn(0, 100)
@@ -71,6 +72,7 @@ class AnalyticFragment : Fragment() {
 
         val hasCategoryData = state.hasCategoryShares
         categoryContainer.isVisible = hasCategoryData
+        tvCategoriesHeader.isVisible = hasCategoryData
         tvCategoriesEmpty.isVisible = !hasCategoryData
 
         if (hasCategoryData) {


### PR DESCRIPTION
## Summary
- hide the overall progress section when no analytics data is available
- hide the category distribution header and show only the empty state container when there is no category data

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d661a3c43c832abcfb5f8238fa9be6