### PR TITLE
Replace goal placeholders with place_holder_prime

### DIFF
--- a/app/src/main/java/be/buithg/supergoal/presentation/ui/goal/GoalAdapter.kt
+++ b/app/src/main/java/be/buithg/supergoal/presentation/ui/goal/GoalAdapter.kt
@@ -67,10 +67,10 @@ class GoalAdapter(
                         ivCover.setImageURI(null)
                         ivCover.setImageURI(uri)
                     }
-                    else -> ivCover.setImageResource(R.drawable.ic_launcher_background)
+                    else -> ivCover.setImageResource(R.drawable.place_holder_prime)
                 }
             } else {
-                ivCover.setImageResource(R.drawable.ic_launcher_background)
+                ivCover.setImageResource(R.drawable.place_holder_prime)
             }
 
             root.setOnClickListener { onGoalClick(item) }
@@ -94,10 +94,10 @@ class GoalAdapter(
                     ivCover.setImageURI(null)
                     ivCover.setImageURI(uri)
                 } else {
-                    ivCover.setImageResource(R.drawable.ic_launcher_background)
+                    ivCover.setImageResource(R.drawable.place_holder_prime)
                 }
             } else {
-                ivCover.setImageResource(R.drawable.ic_launcher_background)
+                ivCover.setImageResource(R.drawable.place_holder_prime)
             }
 
             root.setOnClickListener { onGoalClick(item) }

--- a/app/src/main/res/drawable/goal_item_completed.xml
+++ b/app/src/main/res/drawable/goal_item_completed.xml
@@ -17,7 +17,7 @@
         android:paddingVertical="2dp"
         android:scaleType="centerCrop"
         android:contentDescription="@string/app_name"
-        android:src="@drawable/ic_launcher_background"
+        android:src="@drawable/place_holder_prime"
         app:layout_constraintDimensionRatio="1:1"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"

--- a/app/src/main/res/layout/challenge_item_completed.xml
+++ b/app/src/main/res/layout/challenge_item_completed.xml
@@ -18,7 +18,7 @@
         android:paddingStart="10dp"
         android:paddingEnd="5dp"
         android:scaleType="centerCrop"
-        android:src="@drawable/ic_launcher_background"
+        android:src="@drawable/place_holder_prime"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintDimensionRatio="1:1"
         app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/fragment_goal_detail.xml
+++ b/app/src/main/res/layout/fragment_goal_detail.xml
@@ -47,7 +47,7 @@
                     app:strokeColor="#F23230"
                     app:strokeWidth="1dp"
                     android:scaleType="centerCrop"
-                    android:src="@drawable/ic_launcher_background"
+                    android:src="@drawable/place_holder_prime"
                     app:shapeAppearanceOverlay="@style/CircleImageView" />
 
 

--- a/app/src/main/res/layout/motivation_item.xml
+++ b/app/src/main/res/layout/motivation_item.xml
@@ -17,7 +17,7 @@
         android:paddingVertical="10dp"
         android:scaleType="centerCrop"
         android:contentDescription="@string/app_name"
-        android:src="@drawable/ic_launcher_background"
+        android:src="@drawable/place_holder_prime"
         app:layout_constraintDimensionRatio="1:1"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"


### PR DESCRIPTION
## Summary
- update goal- and motivation-related layouts to reference the new `place_holder_prime` drawable
- ensure goal adapter uses `place_holder_prime` as the default image fallback

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6ac56f9c4832aa7ca2901acbb1137